### PR TITLE
Fix for Issue #322

### DIFF
--- a/src/modules/paymentProcessor/IStreamingPaymentProcessor.sol
+++ b/src/modules/paymentProcessor/IStreamingPaymentProcessor.sol
@@ -115,18 +115,18 @@ interface IStreamingPaymentProcessor is IPaymentProcessor {
 
     /// @notice claim everything that the paymentClient owes to the _msgSender till the current timestamp
     /// @dev This function should be callable if the _msgSender is either an activePaymentReceiver or has some unclaimedAmounts
-    /// @param client The {IERC20PaymentClient} instance to process all claims from _msgSender
-    function claimAll(IERC20PaymentClient client) external;
+    /// @param client The IERC20PaymentClient instance address that processes all claims from _msgSender
+    function claimAll(address client) external;
 
     /// @notice claim the salary uptil block.timestamp from the client for a payment order with id = walletId by _msgSender
     /// @dev If for a specific walletId, the tokens could not be transferred for some reason, it will added to the unclaimableAmounts
     ///      of the paymentReceiver, and the amount would no longer hold any co-relation with the specific walletId of the paymentReceiver.
-    /// @param client The {IERC20PaymentClient} instance to process the walletId claim from _msgSender
+    /// @param client The {IERC20PaymentClient} instance address that processes the walletId claim from _msgSender
     /// @param walletId The ID of the payment order for which claim is being made
     /// @param retryForUnclaimableAmounts boolean which determines if the function will try to pay the unclaimable amounts from earlier
     ///        along with the vested salary from the payment order with id = walletId
     function claimForSpecificWalletId(
-        IERC20PaymentClient client,
+        address client,
         uint walletId,
         bool retryForUnclaimableAmounts
     ) external;
@@ -135,23 +135,23 @@ interface IStreamingPaymentProcessor is IPaymentProcessor {
     /// @dev this function calls _removePayment which goes through all the payment orders for a paymentReceiver. For the payment orders
     ///      that are completely vested, their details are deleted in the _claimForSpecificWalletId function and for others it is
     ///      deleted in the _removePayment function only, leaving the unvested tokens as balance of the paymentClient itself.
-    /// @param client The {IERC20PaymentClient} instance from which we will remove the payments
+    /// @param client The {IERC20PaymentClient} instance address from which we will remove the payments
     /// @param paymentReceiver PaymentReceiver's address.
     function removeAllPaymentReceiverPayments(
-        IERC20PaymentClient client,
+        address client,
         address paymentReceiver
     ) external;
 
     /// @notice Deletes a specific payment with id = walletId for a paymentReceiver & leaves unvested tokens in the ERC20PaymentClient.
     /// @dev the detail of the wallet that is being removed is either deleted in the _claimForSpecificWalletId or later down in this
     ///      function itself depending on the timestamp of when this function was called
-    /// @param client The {IERC20PaymentClient} instance from which we will remove the payment
+    /// @param client The {IERC20PaymentClient} instance address from which we will remove the payment
     /// @param paymentReceiver address of the paymentReceiver whose payment order is to be removed
     /// @param walletId The ID of the paymentReceiver's payment order which is to be removed
     /// @param retryForUnclaimableAmounts boolean that determines whether the function would try to return the unclaimableAmounts along
     ///        with the vested amounts from the payment order with id = walletId to the paymentReceiver
     function removePaymentForSpecificWalletId(
-        IERC20PaymentClient client,
+        address client,
         address paymentReceiver,
         uint walletId,
         bool retryForUnclaimableAmounts

--- a/src/modules/paymentProcessor/StreamingPaymentProcessor.sol
+++ b/src/modules/paymentProcessor/StreamingPaymentProcessor.sol
@@ -62,8 +62,8 @@ contract StreamingPaymentProcessor is Module, IStreamingPaymentProcessor {
     }
 
     /// @notice checks that the client is calling for itself
-    modifier validClient(IERC20PaymentClient client) {
-        if (_msgSender() != address(client)) {
+    modifier validClient(address client) {
+        if (_msgSender() != client) {
             revert Module__PaymentManager__CannotCallOnOtherClientsOrders();
         }
         _;
@@ -91,48 +91,47 @@ contract StreamingPaymentProcessor is Module, IStreamingPaymentProcessor {
     }
 
     /// @inheritdoc IStreamingPaymentProcessor
-    function claimAll(IERC20PaymentClient client) external {
+    function claimAll(address client) external {
         if (
             !(
-                unclaimable(address(client), _msgSender()) > 0
-                    || activeVestingWallets[address(client)][_msgSender()].length
-                        > 0
+                unclaimable(client, _msgSender()) > 0
+                    || activeVestingWallets[client][_msgSender()].length > 0
             )
         ) {
             revert Module__PaymentProcessor__NothingToClaim(
-                address(client), _msgSender()
+                client, _msgSender()
             );
         }
 
-        _claimAll(address(client), _msgSender());
+        _claimAll(client, _msgSender());
     }
 
     /// @inheritdoc IStreamingPaymentProcessor
     function claimForSpecificWalletId(
-        IERC20PaymentClient client,
+        address client,
         uint walletId,
         bool retryForUnclaimableAmounts
     ) external {
         if (
-            activeVestingWallets[address(client)][_msgSender()].length == 0
-                || walletId > numVestingWallets[address(client)][_msgSender()]
+            activeVestingWallets[client][_msgSender()].length == 0
+                || walletId > numVestingWallets[client][_msgSender()]
         ) {
             revert Module__PaymentProcessor__InvalidWallet(
-                address(client), _msgSender(), walletId
+                client, _msgSender(), walletId
             );
         }
 
         if (
-            _findActiveWalletId(address(client), _msgSender(), walletId)
+            _findActiveWalletId(client, _msgSender(), walletId)
                 == type(uint).max
         ) {
             revert Module__PaymentProcessor__InactiveWallet(
-                address(client), _msgSender(), walletId
+                client, _msgSender(), walletId
             );
         }
 
         _claimForSpecificWalletId(
-            address(client), _msgSender(), walletId, retryForUnclaimableAmounts
+            client, _msgSender(), walletId, retryForUnclaimableAmounts
         );
     }
 
@@ -140,7 +139,7 @@ contract StreamingPaymentProcessor is Module, IStreamingPaymentProcessor {
     function processPayments(IERC20PaymentClient client)
         external
         onlyModule
-        validClient(client)
+        validClient(address(client))
     {
         //We check if there are any new paymentOrders, without processing them
         if (client.paymentOrders().length > 0) {
@@ -199,51 +198,46 @@ contract StreamingPaymentProcessor is Module, IStreamingPaymentProcessor {
     function cancelRunningPayments(IERC20PaymentClient client)
         external
         onlyModule
-        validClient(client)
+        validClient(address(client))
     {
         _cancelRunningOrders(address(client));
     }
 
     /// @inheritdoc IStreamingPaymentProcessor
     function removeAllPaymentReceiverPayments(
-        IERC20PaymentClient client,
+        address client,
         address paymentReceiver
     ) external onlyAuthorized {
         if (
-            _findAddressInActiveVestings(address(client), paymentReceiver)
+            _findAddressInActiveVestings(client, paymentReceiver)
                 == type(uint).max
         ) {
             revert Module__PaymentProcessor__InvalidPaymentReceiver(
-                address(client), paymentReceiver
+                client, paymentReceiver
             );
         }
-        _removePayment(address(client), paymentReceiver);
+        _removePayment(client, paymentReceiver);
     }
 
     /// @inheritdoc IStreamingPaymentProcessor
     function removePaymentForSpecificWalletId(
-        IERC20PaymentClient client,
+        address client,
         address paymentReceiver,
         uint walletId,
         bool retryForUnclaimableAmounts
     ) external onlyAuthorized {
         // First, we give the vested funds from this specific walletId to the beneficiary
         _claimForSpecificWalletId(
-            address(client),
-            paymentReceiver,
-            walletId,
-            retryForUnclaimableAmounts
+            client, paymentReceiver, walletId, retryForUnclaimableAmounts
         );
 
         // Now, we need to check when this function was called to determine if we need to delete the details pertaining to this wallet or not
         // We will delete the payment order in question, if it hasn't already reached the end of its duration.
         if (
             block.timestamp
-                < dueToForSpecificWalletId(
-                    address(client), paymentReceiver, walletId
-                )
+                < dueToForSpecificWalletId(client, paymentReceiver, walletId)
         ) {
-            _afterClaimCleanup(address(client), paymentReceiver, walletId);
+            _afterClaimCleanup(client, paymentReceiver, walletId);
         }
     }
 

--- a/test/e2e/RecurringPayments.t.sol
+++ b/test/e2e/RecurringPayments.t.sol
@@ -154,10 +154,10 @@ contract RecurringPayments is E2eTest {
         assertEq(wallets.length, 4);
 
         vm.prank(paymentReceiver2);
-        streamingPaymentProcessor.claimAll(recurringPaymentManager);
+        streamingPaymentProcessor.claimAll(address(recurringPaymentManager));
 
         vm.prank(paymentReceiver1);
-        streamingPaymentProcessor.claimAll(recurringPaymentManager);
+        streamingPaymentProcessor.claimAll(address(recurringPaymentManager));
 
         // PaymentReceiver2 should have got payments from both of their payment orders
         // PaymentReceiver1 should have got payment from one of their payment order

--- a/test/modules/paymentProcessor/StreamingPaymentProcessor.t.sol
+++ b/test/modules/paymentProcessor/StreamingPaymentProcessor.t.sol
@@ -239,7 +239,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
         // All recepients try to claim their vested tokens
         for (uint i; i < recipients.length;) {
             vm.prank(recipients[i]);
-            paymentProcessor.claimAll(paymentClient);
+            paymentProcessor.claimAll(address(paymentClient));
             unchecked {
                 ++i;
             }
@@ -320,7 +320,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
                 );
 
                 vm.prank(recipient);
-                paymentProcessor.claimAll(paymentClient);
+                paymentProcessor.claimAll(address(paymentClient));
 
                 // Check correct balances.
                 assertEq(_token.balanceOf(recipient), payoutAmount);
@@ -647,7 +647,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
 
         vm.prank(address(this)); // stupid line, ik, but it's just here to show that onlyAuthorized can call the next function
         paymentProcessor.removePaymentForSpecificWalletId(
-            paymentClient, paymentReceiver1, walletId, false
+            address(paymentClient), paymentReceiver1, walletId, false
         );
 
         paymentReceiverWallets = paymentProcessor.viewAllPaymentOrders(
@@ -749,7 +749,9 @@ contract StreamingPaymentProcessorTest is ModuleTest {
         // Now we claim the entire salary from the first payment order
         vm.prank(paymentReceiver1);
         paymentProcessor.claimForSpecificWalletId(
-            paymentClient, paymentReceiverWallets[0]._vestingWalletID, false
+            address(paymentClient),
+            paymentReceiverWallets[0]._vestingWalletID,
+            false
         );
 
         // Now we note down the balance of the paymentReceiver1 again after claiming for the first wallet.
@@ -768,7 +770,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
 
         vm.prank(address(this)); // stupid line, ik, but it's just here to show that onlyAuthorized can call the next function
         paymentProcessor.removePaymentForSpecificWalletId(
-            paymentClient,
+            address(paymentClient),
             paymentReceiver1,
             paymentReceiverWallets[1]._vestingWalletID,
             false
@@ -795,7 +797,9 @@ contract StreamingPaymentProcessorTest is ModuleTest {
 
         vm.prank(paymentReceiver1);
         paymentProcessor.claimForSpecificWalletId(
-            paymentClient, paymentReceiverWallets[0]._vestingWalletID, false
+            address(paymentClient),
+            paymentReceiverWallets[0]._vestingWalletID,
+            false
         );
 
         finalPaymentReceiverBalance = _token.balanceOf(paymentReceiver1);
@@ -1066,7 +1070,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
                     recipient
                 )
             );
-            paymentProcessor.claimAll(paymentClient);
+            paymentProcessor.claimAll(address(paymentClient));
             vm.stopPrank();
 
             uint balanceAfter = _token.balanceOf(recipient);
@@ -1197,7 +1201,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
         // FF 25% and claim.
         vm.warp(block.timestamp + duration / 4);
         vm.prank(recipient);
-        paymentProcessor.claimAll(paymentClient);
+        paymentProcessor.claimAll(address(paymentClient));
 
         // after failed claim attempt receiver should receive 0 token,
         // while VPP should move recipient's balances from 'releasable' to 'unclaimable'
@@ -1219,7 +1223,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
         // FF 25% and claim.
         vm.warp(block.timestamp + duration / 4);
         vm.prank(recipient);
-        paymentProcessor.claimAll(paymentClient);
+        paymentProcessor.claimAll(address(paymentClient));
 
         // after successful claim attempt receiver should 50% total,
         // while both 'releasable' and 'unclaimable' recipient's amounts should be 0
@@ -1263,7 +1267,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
         // FF 25% and claim.
         vm.warp(block.timestamp + duration / 4);
         vm.prank(recipient);
-        paymentProcessor.claimAll(paymentClient);
+        paymentProcessor.claimAll(address(paymentClient));
 
         // after failed claim attempt receiver should receive 0 token,
         // while VPP should move recipient's balances from 'releasable' to 'unclaimable'
@@ -1285,7 +1289,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
         // FF 25% and claim.
         vm.warp(block.timestamp + duration / 4);
         vm.prank(recipient);
-        paymentProcessor.claimAll(paymentClient);
+        paymentProcessor.claimAll(address(paymentClient));
 
         // after successful claim attempt receiver should 50% total,
         // while both 'releasable' and 'unclaimable' recipient's amounts should be 0
@@ -1339,7 +1343,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
 
         for (uint i; i < recipients.length; i++) {
             vm.prank(address(recipients[i]));
-            paymentProcessor.claimAll(paymentClient);
+            paymentProcessor.claimAll(address(paymentClient));
         }
     }
 


### PR DESCRIPTION
As mentioned in issue #322, I have converted the parameter type from `IERC20PaymentClient` to `address` wherever possible without changing the interface of `IPaymentProcessor` (since it is the general interface for all other types of payment processors as well) for the convenience of the end-users.