### PR TITLE
Feat: Add MetaTx support to contracts

### DIFF
--- a/script/modules/DeployBountyManager.s.sol
+++ b/script/modules/DeployBountyManager.s.sol
@@ -26,7 +26,7 @@ contract DeployBountyManager is Script {
         {
             // Deploy the singleVoteGovernor.
 
-            bountyManager = new BountyManager();
+            bountyManager = new BountyManager(address(0));
         }
 
         vm.stopBroadcast();

--- a/script/modules/DeploySingleVoteGovernor.s.sol
+++ b/script/modules/DeploySingleVoteGovernor.s.sol
@@ -26,7 +26,7 @@ contract DeploySingleVoteGovernor is Script {
         {
             // Deploy the singleVoteGovernor.
 
-            singleVoteGovernor = new SingleVoteGovernor();
+            singleVoteGovernor = new SingleVoteGovernor(address(0));
         }
 
         vm.stopBroadcast();

--- a/script/modules/fundingManager/DeployBancorVirtualSupplyBondingCurveFundingManager.s.sol
+++ b/script/modules/fundingManager/DeployBancorVirtualSupplyBondingCurveFundingManager.s.sol
@@ -26,7 +26,8 @@ contract DeployBancorVirtualSupplyBondingCurveFundingManager is Script {
         {
             // Deploy the BancorVirtualSupplyBondingCurveFundingManager.
 
-            fundingManager = new BancorVirtualSupplyBondingCurveFundingManager();
+            fundingManager =
+                new BancorVirtualSupplyBondingCurveFundingManager(address(0));
         }
 
         vm.stopBroadcast();

--- a/script/modules/fundingManager/DeployRebasingFundingManager.s.sol
+++ b/script/modules/fundingManager/DeployRebasingFundingManager.s.sol
@@ -26,7 +26,7 @@ contract DeployRebasingFundingManager is Script {
         {
             // Deploy the RebasingFundingManager.
 
-            fundingManager = new RebasingFundingManager();
+            fundingManager = new RebasingFundingManager(address(0));
         }
 
         vm.stopBroadcast();

--- a/script/modules/governance/DeployRoleAuthorizer.s.sol
+++ b/script/modules/governance/DeployRoleAuthorizer.s.sol
@@ -26,7 +26,7 @@ contract DeployRoleAuthorizer is Script {
         {
             // Deploy the listAuthorizer.
 
-            roleAuthorizer = new RoleAuthorizer();
+            roleAuthorizer = new RoleAuthorizer(address(0));
         }
 
         vm.stopBroadcast();

--- a/script/modules/governance/DeployTokenGatedRoleAuthorizer.s.sol
+++ b/script/modules/governance/DeployTokenGatedRoleAuthorizer.s.sol
@@ -27,7 +27,7 @@ contract DeployTokenGatedRoleAuthorizer is Script {
         {
             // Deploy the listAuthorizer.
 
-            tokenRoleAuthorizer = new TokenGatedRoleAuthorizer();
+            tokenRoleAuthorizer = new TokenGatedRoleAuthorizer(address(0));
         }
 
         vm.stopBroadcast();

--- a/script/modules/paymentProcessor/DeploySimplePaymentProcessor.s.sol
+++ b/script/modules/paymentProcessor/DeploySimplePaymentProcessor.s.sol
@@ -26,7 +26,7 @@ contract DeploySimplePaymentProcessor is Script {
         {
             // Deploy the SimplePaymentProcessor.
 
-            paymentProcessor = new SimplePaymentProcessor();
+            paymentProcessor = new SimplePaymentProcessor(address(0));
         }
 
         vm.stopBroadcast();

--- a/script/modules/paymentProcessor/DeployStreamingPaymentProcessor.s.sol
+++ b/script/modules/paymentProcessor/DeployStreamingPaymentProcessor.s.sol
@@ -26,7 +26,7 @@ contract DeployStreamingPaymentProcessor is Script {
         {
             // Deploy the StreamingPaymentProcessor.
 
-            paymentProcessor = new StreamingPaymentProcessor();
+            paymentProcessor = new StreamingPaymentProcessor(address(0));
         }
         vm.stopBroadcast();
 

--- a/script/orchestrator/DeployOrchestrator.s.sol
+++ b/script/orchestrator/DeployOrchestrator.s.sol
@@ -26,7 +26,7 @@ contract DeployOrchestrator is Script {
         {
             // Deploy the orchestrator.
 
-            orchestrator = new Orchestrator();
+            orchestrator = new Orchestrator(address(0));
         }
 
         vm.stopBroadcast();

--- a/src/common/MinimalPausableForwarder.sol
+++ b/src/common/MinimalPausableForwarder.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.19;
+
+import "@oz/utils/cryptography/ECDSA.sol";
+import "@oz/utils/cryptography/EIP712.sol";
+import "@oz/security/Pausable.sol";
+
+/**
+ * @dev Simple minimal forwarder to be used together with an ERC2771 compatible contract. See {ERC2771Context}.
+ *
+ * MinimalForwarder is mainly meant for testing, as it is missing features to be a good production-ready forwarder. This
+ * contract does not intend to have all the properties that are needed for a sound forwarding system. A fully
+ * functioning forwarding system with good properties requires more complexity. We suggest you look at other projects
+ * such as the GSN which do have the goal of building a system like that.
+ */
+contract MinimalPausableForwarder is EIP712, Pausable {
+    using ECDSA for bytes32;
+
+    event PauserChanged(address oldPauser, address newPauser);
+
+    struct ForwardRequest {
+        address from;
+        address to;
+        uint value;
+        uint gas;
+        uint nonce;
+        bytes data;
+    }
+
+    bytes32 private constant _TYPEHASH = keccak256(
+        "ForwardRequest(address from,address to,uint256 value,uint256 gas,uint256 nonce,bytes data)"
+    );
+
+    mapping(address => uint) private _nonces;
+
+    address public pauser;
+
+    constructor(address _pauser) EIP712("MinimalPausableForwarder", "0.0.1") {
+        pauser = _pauser;
+    }
+
+    function setPauser(address _newPauser) external {
+        emit PauserChanged(pauser, _newPauser);
+        pauser = _newPauser;
+    }
+
+    function getNonce(address from) public view returns (uint) {
+        return _nonces[from];
+    }
+
+    function verify(ForwardRequest calldata req, bytes calldata signature)
+        public
+        view
+        returns (bool)
+    {
+        address signer = _hashTypedDataV4(
+            keccak256(
+                abi.encode(
+                    _TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        ).recover(signature);
+        return _nonces[req.from] == req.nonce && signer == req.from;
+    }
+
+    function execute(ForwardRequest calldata req, bytes calldata signature)
+        public
+        payable
+        whenNotPaused
+        returns (bool, bytes memory)
+    {
+        require(
+            verify(req, signature),
+            "MinimalForwarder: signature does not match request"
+        );
+        _nonces[req.from] = req.nonce + 1;
+
+        (bool success, bytes memory returndata) = req.to.call{
+            gas: req.gas,
+            value: req.value
+        }(abi.encodePacked(req.data, req.from));
+
+        // Validate that the relayer has sent enough gas for the call.
+        // See https://ronan.eth.limo/blog/ethereum-gas-dangers/
+        if (gasleft() <= req.gas / 63) {
+            // We explicitly trigger invalid opcode to consume all gas and bubble-up the effects, since
+            // neither revert or assert consume all gas since Solidity 0.8.0
+            // https://docs.soliditylang.org/en/v0.8.0/control-structures.html#panic-via-assert-and-error-via-require
+            /// @solidity memory-safe-assembly
+            assembly {
+                invalid()
+            }
+        }
+
+        return (success, returndata);
+    }
+}

--- a/src/common/TransactionSupport.sol
+++ b/src/common/TransactionSupport.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.19;
+
+import {ERC2771ContextUpgradeable} from
+    "@oz-up/metatx/ERC2771ContextUpgradeable.sol";
+
+abstract contract TransactionSupport is ERC2771ContextUpgradeable {
+    constructor(address _trustedForwarder)
+        ERC2771ContextUpgradeable(_trustedForwarder)
+    {}
+
+    function _msgSender()
+        internal
+        view
+        virtual
+        override
+        returns (address sender)
+    {
+        return super._msgSender();
+    }
+}

--- a/src/modules/authorizer/RoleAuthorizer.sol
+++ b/src/modules/authorizer/RoleAuthorizer.sol
@@ -2,8 +2,10 @@
 pragma solidity 0.8.19;
 // External Libraries
 
-import {AccessControlEnumerableUpgradeable} from
-    "@oz-up/access/AccessControlEnumerableUpgradeable.sol";
+import {
+    AccessControlEnumerableUpgradeable,
+    ContextUpgradeable
+} from "@oz-up/access/AccessControlEnumerableUpgradeable.sol";
 import {Module, IModule} from "src/modules/base/Module.sol";
 import {IAuthorizer} from "./IAuthorizer.sol";
 import {IOrchestrator} from "src/orchestrator/IOrchestrator.sol";
@@ -48,7 +50,7 @@ contract RoleAuthorizer is
     //--------------------------------------------------------------------------
     // Constructor and initialization
 
-    constructor() {
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {
         // make the BURN_ADMIN_ROLE immutable
         _setRoleAdmin(BURN_ADMIN_ROLE, BURN_ADMIN_ROLE);
     }
@@ -200,5 +202,29 @@ contract RoleAuthorizer is
     /// @inheritdoc IAuthorizer
     function getManagerRole() public pure returns (bytes32) {
         return ORCHESTRATOR_MANAGER_ROLE;
+    }
+
+    /// Needs to be overriden, because they are imported via the AccessControlEnumerableUpgradeable as well
+    /// as via the Module -> ERC2771ContextUpgradeable
+    function _msgSender()
+        internal
+        view
+        virtual
+        override(Module, ContextUpgradeable)
+        returns (address sender)
+    {
+        return super._msgSender();
+    }
+
+    /// Needs to be overriden, because they are imported via the AccessControlEnumerableUpgradeable as well
+    /// as via the Module -> ERC2771ContextUpgradeable
+    function _msgData()
+        internal
+        view
+        virtual
+        override(Module, ContextUpgradeable)
+        returns (bytes calldata)
+    {
+        return super._msgData();
     }
 }

--- a/src/modules/authorizer/TokenGatedRoleAuthorizer.sol
+++ b/src/modules/authorizer/TokenGatedRoleAuthorizer.sol
@@ -63,6 +63,11 @@ contract TokenGatedRoleAuthorizer is
     mapping(bytes32 => uint) public thresholdMap;
 
     //--------------------------------------------------------------------------
+    // Constructor and initialization
+
+    constructor(address _trustedForwarder) RoleAuthorizer(_trustedForwarder) {}
+
+    //--------------------------------------------------------------------------
     // Overloaded and overriden functions
 
     function hasRole(bytes32 roleId, address account)

--- a/src/modules/base/Module.sol
+++ b/src/modules/base/Module.sol
@@ -2,15 +2,14 @@
 pragma solidity 0.8.19;
 
 // External Dependencies
-import {Initializable} from "@oz-up/proxy/utils/Initializable.sol";
-import {ContextUpgradeable} from "@oz-up/utils/ContextUpgradeable.sol";
+import {ERC2771ContextUpgradeable} from
+    "@oz-up/metatx/ERC2771ContextUpgradeable.sol";
 
 // Internal Libraries
 import {LibMetadata} from "src/modules/lib/LibMetadata.sol";
 
 // Internal Interfaces
 import {IModule, IOrchestrator} from "src/modules/base/IModule.sol";
-import {IAuthorizer} from "src/modules/authorizer/IAuthorizer.sol";
 import {IAuthorizer} from "src/modules/authorizer/IAuthorizer.sol";
 
 /**
@@ -31,7 +30,7 @@ import {IAuthorizer} from "src/modules/authorizer/IAuthorizer.sol";
  *
  * @author Inverter Network
  */
-abstract contract Module is IModule, Initializable, ContextUpgradeable {
+abstract contract Module is IModule, ERC2771ContextUpgradeable {
     //--------------------------------------------------------------------------
     // Storage
     //
@@ -138,9 +137,9 @@ abstract contract Module is IModule, Initializable, ContextUpgradeable {
     //--------------------------------------------------------------------------
     // Initialization
 
-    constructor() {
-        _disableInitializers();
-    }
+    constructor(address _trustedForwarder)
+        ERC2771ContextUpgradeable(_trustedForwarder)
+    {}
 
     /// @inheritdoc IModule
     function init(
@@ -268,5 +267,25 @@ abstract contract Module is IModule, Initializable, ContextUpgradeable {
         } catch {
             return false;
         }
+    }
+
+    function _msgSender()
+        internal
+        view
+        virtual
+        override(ERC2771ContextUpgradeable)
+        returns (address sender)
+    {
+        return super._msgSender();
+    }
+
+    function _msgData()
+        internal
+        view
+        virtual
+        override(ERC2771ContextUpgradeable)
+        returns (bytes calldata)
+    {
+        return super._msgData();
     }
 }

--- a/src/modules/fundingManager/RebasingFundingManager.sol
+++ b/src/modules/fundingManager/RebasingFundingManager.sol
@@ -7,8 +7,6 @@ import {
     ElasticReceiptTokenUpgradeable,
     ElasticReceiptTokenBase
 } from "src/modules/fundingManager/token/ElasticReceiptTokenUpgradeable.sol";
-import {Initializable} from "@oz-up/proxy/utils/Initializable.sol";
-import {ContextUpgradeable} from "@oz-up/utils/ContextUpgradeable.sol";
 
 // Internal Interfaces
 import {IOrchestrator} from "src/orchestrator/IOrchestrator.sol";
@@ -29,7 +27,6 @@ import {IFundingManager} from "src/modules/fundingManager/IFundingManager.sol";
 contract RebasingFundingManager is
     IFundingManager,
     IRebasingERC20,
-    ContextUpgradeable,
     ElasticReceiptTokenUpgradeable,
     Module
 {
@@ -59,6 +56,8 @@ contract RebasingFundingManager is
 
     //--------------------------------------------------------------------------
     // Init Function
+
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {}
 
     /// @inheritdoc Module
     function init(

--- a/src/modules/fundingManager/bondingCurveFundingManager/BancorVirtualSupplyBondingCurveFundingManager.sol
+++ b/src/modules/fundingManager/bondingCurveFundingManager/BancorVirtualSupplyBondingCurveFundingManager.sol
@@ -85,6 +85,10 @@ contract BancorVirtualSupplyBondingCurveFundingManager is
     //--------------------------------------------------------------------------
     // Init Function
 
+    constructor(address _trustedForwarder)
+        RedeemingBondingCurveFundingManagerBase(_trustedForwarder)
+    {}
+
     /// @inheritdoc Module
     function init(
         IOrchestrator orchestrator_,

--- a/src/modules/fundingManager/bondingCurveFundingManager/BondingCurveFundingManagerBase.sol
+++ b/src/modules/fundingManager/bondingCurveFundingManager/BondingCurveFundingManagerBase.sol
@@ -9,7 +9,6 @@ import {IBondingCurveFundingManagerBase} from
 
 // Internal Interfaces
 import {IOrchestrator} from "src/orchestrator/IOrchestrator.sol";
-import {ContextUpgradeable} from "@oz-up/utils/ContextUpgradeable.sol";
 
 // External Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
@@ -17,7 +16,10 @@ import {IERC20MetadataUpgradeable} from
     "@oz-up/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
 
 // External Dependencies
-import {ERC20Upgradeable} from "@oz-up/token/ERC20/ERC20Upgradeable.sol";
+import {
+    ERC20Upgradeable,
+    ContextUpgradeable
+} from "@oz-up/token/ERC20/ERC20Upgradeable.sol";
 
 // External Libraries
 import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
@@ -33,7 +35,6 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 abstract contract BondingCurveFundingManagerBase is
     IBondingCurveFundingManagerBase,
     IFundingManager,
-    ContextUpgradeable,
     ERC20Upgradeable,
     Module
 {
@@ -69,6 +70,11 @@ abstract contract BondingCurveFundingManagerBase is
         }
         _;
     }
+
+    //--------------------------------------------------------------------------
+    // Initialization
+
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {}
 
     //--------------------------------------------------------------------------
     // Public Functions
@@ -228,5 +234,29 @@ abstract contract BondingCurveFundingManagerBase is
         __Module_orchestrator.fundingManager().token().safeTransfer(to, amount);
 
         emit TransferOrchestratorToken(to, amount);
+    }
+
+    /// Needs to be overriden, because they are imported via the AccessControlEnumerableUpgradeable as well
+    /// as via the Module -> ERC2771ContextUpgradeable
+    function _msgSender()
+        internal
+        view
+        virtual
+        override(Module, ContextUpgradeable)
+        returns (address sender)
+    {
+        return super._msgSender();
+    }
+
+    /// Needs to be overriden, because they are imported via the AccessControlEnumerableUpgradeable as well
+    /// as via the Module -> ERC2771ContextUpgradeable
+    function _msgData()
+        internal
+        view
+        virtual
+        override(Module, ContextUpgradeable)
+        returns (bytes calldata)
+    {
+        return super._msgData();
     }
 }

--- a/src/modules/fundingManager/bondingCurveFundingManager/RedeemingBondingCurveFundingManagerBase.sol
+++ b/src/modules/fundingManager/bondingCurveFundingManager/RedeemingBondingCurveFundingManagerBase.sol
@@ -48,6 +48,13 @@ abstract contract RedeemingBondingCurveFundingManagerBase is
     }
 
     //--------------------------------------------------------------------------
+    // Initialization
+
+    constructor(address _trustedForwarder)
+        BondingCurveFundingManagerBase(_trustedForwarder)
+    {}
+
+    //--------------------------------------------------------------------------
     // Public Functions
 
     /// @inheritdoc IRedeemingBondingCurveFundingManagerBase

--- a/src/modules/logicModule/BountyManager.sol
+++ b/src/modules/logicModule/BountyManager.sol
@@ -81,6 +81,16 @@ contract BountyManager is IBountyManager, ERC20PaymentClient {
         _;
     }
 
+    //--------------------------------------------------------------------------
+    // Initialization
+
+    constructor(address _trustedForwarder)
+        ERC20PaymentClient(_trustedForwarder)
+    {}
+
+    //--------------------------------------------------------------------------
+    // Internal functions
+
     function validContributorsForBounty(
         Contributor[] memory contributors,
         Bounty memory bounty

--- a/src/modules/logicModule/RecurringPaymentManager.sol
+++ b/src/modules/logicModule/RecurringPaymentManager.sol
@@ -74,6 +74,10 @@ contract RecurringPaymentManager is
     //--------------------------------------------------------------------------
     // Initialization
 
+    constructor(address _trustedForwarder)
+        ERC20PaymentClient(_trustedForwarder)
+    {}
+
     /// @inheritdoc Module
     function init(
         IOrchestrator orchestrator_,

--- a/src/modules/logicModule/paymentClient/ERC20PaymentClient.sol
+++ b/src/modules/logicModule/paymentClient/ERC20PaymentClient.sol
@@ -8,7 +8,7 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 
 // Internal Dependencies
-import {Module, ContextUpgradeable} from "src/modules/base/Module.sol";
+import {Module} from "src/modules/base/Module.sol";
 import {
     IERC20PaymentClient,
     IPaymentProcessor
@@ -53,6 +53,11 @@ abstract contract ERC20PaymentClient is IERC20PaymentClient, Module {
 
     /// @dev The current cumulative amount of tokens outstanding.
     uint internal _outstandingTokenAmount;
+
+    //--------------------------------------------------------------------------
+    // Initialization
+
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {}
 
     //--------------------------------------------------------------------------
     // Internal Mutating Functions

--- a/src/modules/paymentProcessor/SimplePaymentProcessor.sol
+++ b/src/modules/paymentProcessor/SimplePaymentProcessor.sol
@@ -48,6 +48,11 @@ contract SimplePaymentProcessor is Module, IPaymentProcessor {
         _;
     }
 
+    //--------------------------------------------------------------------------
+    // Initialization
+
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {}
+
     /// @inheritdoc Module
     function init(
         IOrchestrator orchestrator_,

--- a/src/modules/paymentProcessor/StreamingPaymentProcessor.sol
+++ b/src/modules/paymentProcessor/StreamingPaymentProcessor.sol
@@ -79,7 +79,9 @@ contract StreamingPaymentProcessor is Module, IStreamingPaymentProcessor {
     }
 
     //--------------------------------------------------------------------------
-    // External Functions
+    // Initialization
+
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {}
 
     /// @inheritdoc Module
     function init(
@@ -89,6 +91,9 @@ contract StreamingPaymentProcessor is Module, IStreamingPaymentProcessor {
     ) external override(Module) initializer {
         __Module_init(orchestrator_, metadata);
     }
+
+    //--------------------------------------------------------------------------
+    // External Functions
 
     /// @inheritdoc IStreamingPaymentProcessor
     function claimAll(address client) external {

--- a/src/modules/utils/MetadataManager.sol
+++ b/src/modules/utils/MetadataManager.sol
@@ -19,6 +19,8 @@ contract MetadataManager is IMetadataManager, Module {
     //--------------------------------------------------------------------------
     // Initialization
 
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {}
+
     /// @inheritdoc Module
     function init(
         IOrchestrator orchestrator_,

--- a/src/modules/utils/SingleVoteGovernor.sol
+++ b/src/modules/utils/SingleVoteGovernor.sol
@@ -70,6 +70,8 @@ contract SingleVoteGovernor is ISingleVoteGovernor, Module {
     //--------------------------------------------------------------------------
     // Initialization
 
+    constructor(address _trustedForwarder) Module(_trustedForwarder) {}
+
     /// @inheritdoc Module
     function init(
         IOrchestrator orchestrator_,

--- a/src/orchestrator/Orchestrator.sol
+++ b/src/orchestrator/Orchestrator.sol
@@ -85,9 +85,7 @@ contract Orchestrator is IOrchestrator, ModuleManager {
     //--------------------------------------------------------------------------
     // Initializer
 
-    constructor() {
-        _disableInitializers();
-    }
+    constructor(address _trustedForwarder) ModuleManager(_trustedForwarder) {}
 
     /// @inheritdoc IOrchestrator
     function init(

--- a/src/orchestrator/base/ModuleManager.sol
+++ b/src/orchestrator/base/ModuleManager.sol
@@ -2,8 +2,8 @@
 pragma solidity 0.8.19;
 
 // External Dependencies
-import {ContextUpgradeable} from "@oz-up/utils/ContextUpgradeable.sol";
-import {Initializable} from "@oz-up/proxy/utils/Initializable.sol";
+import {ERC2771ContextUpgradeable} from
+    "@oz-up/metatx/ERC2771ContextUpgradeable.sol";
 
 // Interfaces
 import {IModuleManager} from "src/orchestrator/base/IModuleManager.sol";
@@ -24,11 +24,7 @@ import {IModuleManager} from "src/orchestrator/base/IModuleManager.sol";
  * @author Adapted from Gnosis Safe
  * @author Inverter Network
  */
-abstract contract ModuleManager is
-    IModuleManager,
-    Initializable,
-    ContextUpgradeable
-{
+abstract contract ModuleManager is IModuleManager, ERC2771ContextUpgradeable {
     //--------------------------------------------------------------------------
     // Modifiers
 
@@ -97,6 +93,10 @@ abstract contract ModuleManager is
 
     //--------------------------------------------------------------------------
     // Initializer
+
+    constructor(address _trustedForwarder)
+        ERC2771ContextUpgradeable(_trustedForwarder)
+    {}
 
     function __ModuleManager_init(address[] calldata modules)
         internal

--- a/test/e2e/CreateNewOrchestrator.t.sol
+++ b/test/e2e/CreateNewOrchestrator.t.sol
@@ -110,11 +110,11 @@ contract OrchestratorCreation is Test {
         //Create Beacons
 
         //Create Module Templates
-        fundingManagerTemplate = new RebasingFundingManager();
-        authorizerTemplate = new RoleAuthorizer();
-        paymentProcessorTemplate = new SimplePaymentProcessor();
-        bountyManagerTemplate = new BountyManager();
-        metadataManagerTemplate = new MetadataManager();
+        fundingManagerTemplate = new RebasingFundingManager(address(0));
+        authorizerTemplate = new RoleAuthorizer(address(0));
+        paymentProcessorTemplate = new SimplePaymentProcessor(address(0));
+        bountyManagerTemplate = new BountyManager(address(0));
+        metadataManagerTemplate = new MetadataManager(address(0));
 
         //Create Beacons for every Module
         fundingManagerBeacon = new Beacon();
@@ -214,7 +214,7 @@ contract OrchestratorCreation is Test {
         //Set up Orchestrator Factory
 
         //Create orchestrator template
-        orchestratorTemplate = new Orchestrator();
+        orchestratorTemplate = new Orchestrator(address(0));
 
         //Create OrchestratorFactory
         orchestratorFactory = new OrchestratorFactory(

--- a/test/e2e/E2eTest.sol
+++ b/test/e2e/E2eTest.sol
@@ -76,7 +76,7 @@ contract E2eTest is Test {
 
     function setUpRebasingFundingManager() private {
         // Deploy module implementations.
-        rebasingFundingManagerImpl = new RebasingFundingManager();
+        rebasingFundingManagerImpl = new RebasingFundingManager(address(0));
 
         // Deploy module beacons.
         vm.prank(rebasingFundingManagerBeaconOwner);
@@ -113,7 +113,7 @@ contract E2eTest is Test {
     function setUpBancorVirtualSupplyBondingCurveFundingManager() private {
         // Deploy module implementations.
         bancorVirtualSupplyBondingCurveFundingManagerImpl =
-            new BancorVirtualSupplyBondingCurveFundingManager();
+            new BancorVirtualSupplyBondingCurveFundingManager(address(0));
 
         // Deploy module beacons.
         vm.prank(bancorVirtualSupplyBondingCurveFundingManagerBeaconOwner);
@@ -185,7 +185,7 @@ contract E2eTest is Test {
 
     function setUpRoleAuthorizer() private {
         // Deploy module implementations.
-        roleAuthorizerImpl = new RoleAuthorizer();
+        roleAuthorizerImpl = new RoleAuthorizer(address(0));
 
         // Deploy module beacons.
         vm.prank(roleAuthorizerBeaconOwner);
@@ -220,7 +220,7 @@ contract E2eTest is Test {
 
     function setUpTokenGatedRoleAuthorizer() private {
         // Deploy module implementations.
-        tokenRoleAuthorizerImpl = new TokenGatedRoleAuthorizer();
+        tokenRoleAuthorizerImpl = new TokenGatedRoleAuthorizer(address(0));
 
         // Deploy module beacons.
         vm.prank(tokenRoleAuthorizerBeaconOwner);
@@ -259,7 +259,7 @@ contract E2eTest is Test {
 
     function setUpSimplePaymentProcessor() private {
         // Deploy module implementations.
-        paymentProcessorImpl = new SimplePaymentProcessor();
+        paymentProcessorImpl = new SimplePaymentProcessor(address(0));
 
         // Deploy module beacons.
         vm.prank(paymentProcessorBeaconOwner);
@@ -296,7 +296,8 @@ contract E2eTest is Test {
 
     function setUpStreamingPaymentProcessor() private {
         // Deploy module implementations.
-        streamingPaymentProcessorImpl = new StreamingPaymentProcessor();
+        streamingPaymentProcessorImpl =
+            new StreamingPaymentProcessor(address(0));
 
         // Deploy module beacons.
         vm.prank(streamingPaymentProcessorBeaconOwner);
@@ -339,7 +340,7 @@ contract E2eTest is Test {
 
     function setUpRecurringPaymentManager() private {
         // Deploy module implementations.
-        recurringPaymentManagerImpl = new RecurringPaymentManager();
+        recurringPaymentManagerImpl = new RecurringPaymentManager(address(0));
 
         // Deploy module beacons.
         vm.prank(recurringPaymentManagerBeaconOwner);
@@ -373,7 +374,7 @@ contract E2eTest is Test {
 
     function setUpBountyManager() private {
         // Deploy module implementations.
-        bountyManagerImpl = new BountyManager();
+        bountyManagerImpl = new BountyManager(address(0));
 
         // Deploy module beacons.
         vm.prank(bountyManagerBeaconOwner);
@@ -417,7 +418,7 @@ contract E2eTest is Test {
 
     function setSingleVoteGovernor() private {
         // Deploy module implementations.
-        singleVoteGovernorImpl = new SingleVoteGovernor();
+        singleVoteGovernorImpl = new SingleVoteGovernor(address(0));
 
         // Deploy module beacons.
         vm.prank(singleVoteGovernorBeaconOwner);
@@ -435,7 +436,7 @@ contract E2eTest is Test {
 
     function setUp() public {
         // Deploy Orchestrator implementation.
-        orchestratorImpl = new Orchestrator();
+        orchestratorImpl = new Orchestrator(address(0));
 
         // Deploy Factories.
         moduleFactory = new ModuleFactory();

--- a/test/e2e/RegisterModuleAtFactory.t.sol
+++ b/test/e2e/RegisterModuleAtFactory.t.sol
@@ -16,7 +16,7 @@ contract RegisterModuleAtFactory is E2eTest {
     function test_e2e_RegisterModuleAtModuleFactory() public {
         // First deploy a new Module implementation.
         // We will use the SimplePaymentProcessor module as example.
-        SimplePaymentProcessor module = new SimplePaymentProcessor();
+        SimplePaymentProcessor module = new SimplePaymentProcessor(address(0));
 
         // We also need to defined the module's metadata.
         IModule.Metadata memory metadata = IModule.Metadata(

--- a/test/factories/OrchestratorFactory.t.sol
+++ b/test/factories/OrchestratorFactory.t.sol
@@ -78,7 +78,7 @@ contract OrchestratorFactoryTest is Test {
     function setUp() public {
         moduleFactory = new ModuleFactoryMock();
 
-        target = new Orchestrator();
+        target = new Orchestrator(address(0));
 
         factory =
             new OrchestratorFactory(address(target), address(moduleFactory));

--- a/test/modules/MetadataManager.t.sol
+++ b/test/modules/MetadataManager.t.sol
@@ -60,7 +60,7 @@ contract MetadataManagerTest is ModuleTest {
 
         //Add Module to Mock Orchestrator
 
-        address impl = address(new MetadataManager());
+        address impl = address(new MetadataManager(address(0)));
         metadataManager = MetadataManager(Clones.clone(impl));
 
         _setUpOrchestrator(metadataManager);

--- a/test/modules/ModuleTest.sol
+++ b/test/modules/ModuleTest.sol
@@ -54,7 +54,7 @@ abstract contract ModuleTest is Test {
         address[] memory modules = new address[](1);
         modules[0] = address(module);
 
-        address impl = address(new Orchestrator());
+        address impl = address(new Orchestrator(address(0)));
         _orchestrator = Orchestrator(Clones.clone(impl));
 
         _orchestrator.init(

--- a/test/modules/authorizer/RoleAuthorizer.t.sol
+++ b/test/modules/authorizer/RoleAuthorizer.t.sol
@@ -29,7 +29,7 @@ contract RoleAuthorizerTest is Test {
 
     // Mocks
     RoleAuthorizer _authorizer;
-    Orchestrator internal _orchestrator = new Orchestrator();
+    Orchestrator internal _orchestrator = new Orchestrator(address(0));
     ERC20Mock internal _token = new ERC20Mock("Mock Token", "MOCK");
     FundingManagerMock _fundingManager = new FundingManagerMock();
     PaymentProcessorMock _paymentProcessor = new PaymentProcessorMock();
@@ -51,9 +51,9 @@ contract RoleAuthorizerTest is Test {
         IModule.Metadata(MAJOR_VERSION, MINOR_VERSION, URL, TITLE);
 
     function setUp() public virtual {
-        address authImpl = address(new RoleAuthorizer());
+        address authImpl = address(new RoleAuthorizer(address(0)));
         _authorizer = RoleAuthorizer(Clones.clone(authImpl));
-        address propImpl = address(new Orchestrator());
+        address propImpl = address(new Orchestrator(address(0)));
         _orchestrator = Orchestrator(Clones.clone(propImpl));
         ModuleMock module = new  ModuleMock();
         address[] memory modules = new address[](1);
@@ -96,7 +96,7 @@ contract RoleAuthorizerTest is Test {
         //Checks that address list gets correctly stored on initialization
         // We "reuse" the orchestrator created in the setup, but the orchestrator doesn't know about this new authorizer.
 
-        address authImpl = address(new RoleAuthorizer());
+        address authImpl = address(new RoleAuthorizer(address(0)));
         RoleAuthorizer testAuthorizer = RoleAuthorizer(Clones.clone(authImpl));
 
         vm.assume(initialAuth != address(0));
@@ -122,7 +122,7 @@ contract RoleAuthorizerTest is Test {
         //Checks that address list gets correctly stored on initialization if there are no owners given
         // We "reuse" the orchestrator created in the setup, but the orchestrator doesn't know about this new authorizer.
 
-        address authImpl = address(new RoleAuthorizer());
+        address authImpl = address(new RoleAuthorizer(address(0)));
         RoleAuthorizer testAuthorizer = RoleAuthorizer(Clones.clone(authImpl));
 
         address initialAuth = address(0);
@@ -145,7 +145,7 @@ contract RoleAuthorizerTest is Test {
         //Checks that address list gets correctly stored on initialization
         // We "reuse" the orchestrator created in the setup, but the orchestrator doesn't know about this new authorizer.
 
-        address authImpl = address(new RoleAuthorizer());
+        address authImpl = address(new RoleAuthorizer(address(0)));
         RoleAuthorizer testAuthorizer = RoleAuthorizer(Clones.clone(authImpl));
 
         address initialAuth = address(this);
@@ -168,7 +168,7 @@ contract RoleAuthorizerTest is Test {
     function testReinitFails() public {
         //Create a mock new orchestrator
         Orchestrator newOrchestrator =
-            Orchestrator(Clones.clone(address(new Orchestrator())));
+            Orchestrator(Clones.clone(address(new Orchestrator(address(0)))));
 
         address initialOwner = address(this);
         address initialManager = address(this);

--- a/test/modules/authorizer/SingleVoteGovernor.t.sol
+++ b/test/modules/authorizer/SingleVoteGovernor.t.sol
@@ -53,7 +53,7 @@ contract SingleVoteGovernorTest is ModuleTest {
 
     function setUp() public {
         // Set up a orchestrator
-        address authImpl = address(new SingleVoteGovernor());
+        address authImpl = address(new SingleVoteGovernor(address(0)));
         _governor = SingleVoteGovernor(Clones.clone(authImpl));
 
         _setUpOrchestrator(_governor);
@@ -246,7 +246,7 @@ contract SingleVoteGovernorTest is ModuleTest {
         vm.assume(testVoters.length >= 2);
         _validateUserList(testVoters);
 
-        address authImpl = address(new SingleVoteGovernor());
+        address authImpl = address(new SingleVoteGovernor(address(0)));
         SingleVoteGovernor testAuthorizer =
             SingleVoteGovernor(Clones.clone(authImpl));
 
@@ -281,7 +281,7 @@ contract SingleVoteGovernorTest is ModuleTest {
         vm.assume(testVoters.length >= 2);
         position = uint8(bound(position, 1, testVoters.length - 1));
 
-        address authImpl = address(new SingleVoteGovernor());
+        address authImpl = address(new SingleVoteGovernor(address(0)));
         SingleVoteGovernor testAuthorizer =
             SingleVoteGovernor(Clones.clone(authImpl));
 
@@ -312,7 +312,7 @@ contract SingleVoteGovernorTest is ModuleTest {
     function testReinitFails() public override {
         //Create a mock new orchestrator
         Orchestrator newOrchestrator =
-            Orchestrator(Clones.clone(address(new Orchestrator())));
+            Orchestrator(Clones.clone(address(new Orchestrator(address(0)))));
 
         address[] memory testVoters = new address[](1);
         testVoters[0] = address(this);
@@ -343,7 +343,7 @@ contract SingleVoteGovernorTest is ModuleTest {
     function testInitWithInvalidInitialVotersFails() public {
         // We "reuse" the orchestrator created in the setup, but the orchestrator doesn't know about this new authorizer.
 
-        address authImpl = address(new SingleVoteGovernor());
+        address authImpl = address(new SingleVoteGovernor(address(0)));
         SingleVoteGovernor testAuthorizer =
             SingleVoteGovernor(Clones.clone(authImpl));
 

--- a/test/modules/authorizer/TokenGatedRoleAuthorizer.t.sol
+++ b/test/modules/authorizer/TokenGatedRoleAuthorizer.t.sol
@@ -36,11 +36,11 @@ import {PaymentProcessorMock} from
 contract TokenGatedRoleAuthorizerUpstreamTests is RoleAuthorizerTest {
     function setUp() public override {
         //==== We use the TokenGatedRoleAuthorizer as a regular RoleAuthorizer =====
-        address authImpl = address(new TokenGatedRoleAuthorizer());
+        address authImpl = address(new TokenGatedRoleAuthorizer(address(0)));
         _authorizer = RoleAuthorizer(Clones.clone(authImpl));
         //==========================================================================
 
-        address propImpl = address(new Orchestrator());
+        address propImpl = address(new Orchestrator(address(0)));
         _orchestrator = Orchestrator(Clones.clone(propImpl));
         ModuleMock module = new  ModuleMock();
         address[] memory modules = new address[](1);
@@ -79,7 +79,7 @@ contract TokenGatedRoleAuthorizerTest is Test {
 
     // Mocks
     TokenGatedRoleAuthorizer _authorizer;
-    Orchestrator internal _orchestrator = new Orchestrator();
+    Orchestrator internal _orchestrator = new Orchestrator(address(0));
     ERC20Mock internal _token = new ERC20Mock("Mock Token", "MOCK");
     FundingManagerMock _fundingManager = new FundingManagerMock();
     PaymentProcessorMock _paymentProcessor = new PaymentProcessorMock();
@@ -110,9 +110,9 @@ contract TokenGatedRoleAuthorizerTest is Test {
         IModule.Metadata(MAJOR_VERSION, MINOR_VERSION, URL, TITLE);
 
     function setUp() public {
-        address authImpl = address(new TokenGatedRoleAuthorizer());
+        address authImpl = address(new TokenGatedRoleAuthorizer(address(0)));
         _authorizer = TokenGatedRoleAuthorizer(Clones.clone(authImpl));
-        address propImpl = address(new Orchestrator());
+        address propImpl = address(new Orchestrator(address(0)));
         _orchestrator = Orchestrator(Clones.clone(propImpl));
         address[] memory modules = new address[](1);
         modules[0] = address(mockModule);

--- a/test/modules/fundingManager/RebasingFundingManager.t.sol
+++ b/test/modules/fundingManager/RebasingFundingManager.t.sol
@@ -51,7 +51,7 @@ contract RebasingFundingManagerTest is ModuleTest {
 
         //Add Module to Mock Orchestrator
 
-        address impl = address(new RebasingFundingManager());
+        address impl = address(new RebasingFundingManager(address(0)));
         fundingManager = RebasingFundingManager(Clones.clone(impl));
 
         _setUpOrchestrator(fundingManager);

--- a/test/modules/fundingManager/bondingCurveFundingManager/marketMaker/utils/mocks/BancorVirtualSupplyBondingCurveFundingManagerMock.sol
+++ b/test/modules/fundingManager/bondingCurveFundingManager/marketMaker/utils/mocks/BancorVirtualSupplyBondingCurveFundingManagerMock.sol
@@ -23,6 +23,8 @@ contract BancorVirtualSupplyBondingCurveFundingManagerMock is
     // The BancorVirtualSupplyBondingCurveFundingManager is not abstract, so all the necessary functions are already implemented
     // The goal of this mock is to provide direct access to internal functions for testing purposes.
 
+    constructor() BancorVirtualSupplyBondingCurveFundingManager(address(0)) {}
+
     //--------------------------------------------------------------------------
     // Mock access for internal functions
 

--- a/test/modules/fundingManager/bondingCurveFundingManager/marketMaker/utils/mocks/BondingCurveFundingManagerMock.sol
+++ b/test/modules/fundingManager/bondingCurveFundingManager/marketMaker/utils/mocks/BondingCurveFundingManagerMock.sol
@@ -22,6 +22,8 @@ import {IERC20} from "@oz/token/ERC20/IERC20.sol";
 contract BondingCurveFundingManagerMock is BondingCurveFundingManagerBase {
     IBancorFormula public formula;
 
+    constructor() BondingCurveFundingManagerBase(address(0)) {}
+
     function init(
         IOrchestrator orchestrator_,
         Metadata memory metadata,

--- a/test/modules/fundingManager/bondingCurveFundingManager/marketMaker/utils/mocks/RedeemingBondingCurveFundingManagerMock.sol
+++ b/test/modules/fundingManager/bondingCurveFundingManager/marketMaker/utils/mocks/RedeemingBondingCurveFundingManagerMock.sol
@@ -24,6 +24,8 @@ contract RedeemingBondingCurveFundingManagerMock is
 {
     IBancorFormula public formula;
 
+    constructor() RedeemingBondingCurveFundingManagerBase(address(0)) {}
+
     function init(
         IOrchestrator orchestrator_,
         Metadata memory metadata,

--- a/test/modules/logicModule/BountyManager.t.sol
+++ b/test/modules/logicModule/BountyManager.t.sol
@@ -62,7 +62,7 @@ contract BountyManagerTest is ModuleTest {
 
     function setUp() public {
         //Add Module to Mock Orchestrator
-        address impl = address(new BountyManager());
+        address impl = address(new BountyManager(address(0)));
         bountyManager = BountyManager(Clones.clone(impl));
 
         _setUpOrchestrator(bountyManager);

--- a/test/modules/logicModule/RecurringPaymentManager.t.sol
+++ b/test/modules/logicModule/RecurringPaymentManager.t.sol
@@ -40,7 +40,7 @@ contract RecurringPaymentManagerTest is ModuleTest {
 
     function setUp() public {
         //Add Module to Mock Orchestrator
-        address impl = address(new RecurringPaymentManager());
+        address impl = address(new RecurringPaymentManager(address(0)));
         recurringPaymentManager = RecurringPaymentManager(Clones.clone(impl));
 
         _setUpOrchestrator(recurringPaymentManager);

--- a/test/modules/paymentProcessor/SimplePaymentProcessor.t.sol
+++ b/test/modules/paymentProcessor/SimplePaymentProcessor.t.sol
@@ -32,7 +32,7 @@ contract SimplePaymentProcessorTest is ModuleTest {
     ERC20PaymentClientMock paymentClient = new ERC20PaymentClientMock(_token);
 
     function setUp() public {
-        address impl = address(new SimplePaymentProcessor());
+        address impl = address(new SimplePaymentProcessor(address(0)));
         paymentProcessor = SimplePaymentProcessor(Clones.clone(impl));
 
         _setUpOrchestrator(paymentProcessor);

--- a/test/modules/paymentProcessor/StreamingPaymentProcessor.t.sol
+++ b/test/modules/paymentProcessor/StreamingPaymentProcessor.t.sol
@@ -54,7 +54,7 @@ contract StreamingPaymentProcessorTest is ModuleTest {
     );
 
     function setUp() public {
-        address impl = address(new StreamingPaymentProcessor());
+        address impl = address(new StreamingPaymentProcessor(address(0)));
         paymentProcessor = StreamingPaymentProcessor(Clones.clone(impl));
 
         _setUpOrchestrator(paymentProcessor);

--- a/test/orchestrator/Orchestrator.t.sol
+++ b/test/orchestrator/Orchestrator.t.sol
@@ -59,7 +59,7 @@ contract OrchestratorTest is Test {
         paymentProcessor = new PaymentProcessorMock();
         token = new ERC20Mock("TestToken", "TST");
 
-        address impl = address(new Orchestrator());
+        address impl = address(new Orchestrator(address(0)));
         orchestrator = Orchestrator(Clones.clone(impl));
 
         types = new TypeSanityHelper(address(orchestrator));

--- a/test/utils/mocks/modules/AuthorizerMock.sol
+++ b/test/utils/mocks/modules/AuthorizerMock.sol
@@ -24,6 +24,8 @@ contract AuthorizerMock is IAuthorizer, Module {
     //--------------------------------------------------------------------------
     // IModule Functions
 
+    constructor() Module(address(0)) {}
+
     function init(
         IOrchestrator orchestrator_,
         Metadata memory metadata,

--- a/test/utils/mocks/modules/ERC20PaymentClientMock.sol
+++ b/test/utils/mocks/modules/ERC20PaymentClientMock.sol
@@ -21,7 +21,7 @@ contract ERC20PaymentClientMock is ERC20PaymentClient {
 
     mapping(address => bool) authorized;
 
-    constructor(ERC20Mock token_) {
+    constructor(ERC20Mock token_) ERC20PaymentClient(address(0)) {
         token = token_;
     }
 

--- a/test/utils/mocks/modules/FundingManagerMock.sol
+++ b/test/utils/mocks/modules/FundingManagerMock.sol
@@ -16,6 +16,8 @@ contract FundingManagerMock is IFundingManager, Module {
 
     IERC20 private _token;
 
+    constructor() Module(address(0)) {}
+
     function init(
         IOrchestrator orchestrator_,
         Metadata memory metadata,

--- a/test/utils/mocks/modules/base/ModuleMock.sol
+++ b/test/utils/mocks/modules/base/ModuleMock.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.0;
 import {Module, IModule, IOrchestrator} from "src/modules/base/Module.sol";
 
 contract ModuleMock is Module {
+    constructor() Module(address(0)) {}
+
     function init(
         IOrchestrator orchestrator_,
         Metadata memory metadata,

--- a/test/utils/mocks/orchestrator/base/ModuleManagerMock.sol
+++ b/test/utils/mocks/orchestrator/base/ModuleManagerMock.sol
@@ -20,6 +20,8 @@ contract ModuleManagerMock is ModuleManager {
         _allAuthorized = to;
     }
 
+    constructor() ModuleManager(address(0)) {}
+
     function init(address[] calldata modules) external initializer {
         __ModuleManager_init(modules);
     }


### PR DESCRIPTION
This PR adds the metatx support according to ERC2771 to the contracts.

Open Todos for me:
- Finalize MinimalForwarder to be ready
- Add basic test for metatx to be working
- Add tests for MinimalForwarder
- Adapt scripts & tests to also deploy the Forwarder if not done yet (so no `address(0)` anymore)