### PR TITLE
CI FIX: solved address collision in bc test

### DIFF
--- a/test/modules/fundingManager/bondingCurveFundingManager/BancorVirtualSupplyBondingCurveFundingManager.t.sol
+++ b/test/modules/fundingManager/bondingCurveFundingManager/BancorVirtualSupplyBondingCurveFundingManager.t.sol
@@ -1546,7 +1546,7 @@ contract BancorVirtualSupplyBondingCurveFundingManagerTest is ModuleTest {
     */
 
     function testTransferOrchestratorToken(address to, uint amount) public {
-        vm.assume(to != address(0));
+        vm.assume(to != address(0) && to != address(bondingCurveFundingManager));
 
         _token.mint(address(bondingCurveFundingManager), amount);
 


### PR DESCRIPTION
## What has been done?
Within this [PR](https://github.com/InverterNetwork/inverter-contracts/pull/421), the CI came up with another test failure in the BC tests. These happen because of address collision, and has been solved in this PR