### PR TITLE
Feat: Allow zero minor version for first implementation

### DIFF
--- a/script/deployment/DeploymentScript.s.sol
+++ b/script/deployment/DeploymentScript.s.sol
@@ -151,7 +151,7 @@ contract DeploymentScript is Script {
 
     IModule.Metadata rebasingFundingManagerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "RebasingFundingManager"
     );
@@ -159,7 +159,7 @@ contract DeploymentScript is Script {
     IModule.Metadata bancorVirtualSupplyBondingCurveFundingManagerMetadata =
     IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "BancorVirtualSupplyBondingCurveFundingManager"
     );
@@ -169,14 +169,14 @@ contract DeploymentScript is Script {
 
     IModule.Metadata roleAuthorizerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "RoleAuthorizer"
     );
 
     IModule.Metadata tokenGatedRoleAuthorizerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "TokenGatedRoleAuthorizer"
     );
@@ -186,14 +186,14 @@ contract DeploymentScript is Script {
 
     IModule.Metadata simplePaymentProcessorMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "SimplePaymentProcessor"
     );
 
     IModule.Metadata streamingPaymentProcessorMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "StreamingPaymentProcessor"
     );
@@ -203,14 +203,14 @@ contract DeploymentScript is Script {
 
     IModule.Metadata recurringPaymentManagerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "RecurringPaymentManager"
     );
 
     IModule.Metadata bountyManagerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "BountyManager"
     );
@@ -220,14 +220,14 @@ contract DeploymentScript is Script {
 
     IModule.Metadata singleVoteGovernorMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "SingleVoteGovernor"
     );
 
     IModule.Metadata metadataManagerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/InverterNetwork/inverter-contracts",
         "MetadataManager"
     );
@@ -266,7 +266,7 @@ contract DeploymentScript is Script {
 
         //Deploy beacon and actual proxy
         (forwarderBeacon, forwarder) = deployAndSetUpBeacon
-            .deployBeaconAndSetupProxy(deployer, forwarderImplementation, 1, 1);
+            .deployBeaconAndSetupProxy(deployer, forwarderImplementation, 1, 0);
 
         if (
             forwarder == forwarderImplementation || forwarder == forwarderBeacon

--- a/script/utils/deployTokenAuthorizerAndSwitch.s.sol
+++ b/script/utils/deployTokenAuthorizerAndSwitch.s.sol
@@ -45,7 +45,7 @@ contract deployAndSwitchTokenAuthorizer is Script {
     // Set the Module Metadata.
     // ===============================================================================================================
     IModule.Metadata authorizerMetadata = IModule.Metadata(
-        1, 1, "https://github.com/InverterNetwork", "TokenAuthorizer"
+        1, 0, "https://github.com/InverterNetwork", "TokenAuthorizer"
     );
 
     ModuleFactory moduleFactory = ModuleFactory(moduleFactoryAddress);

--- a/src/factories/beacon/InverterBeacon.sol
+++ b/src/factories/beacon/InverterBeacon.sol
@@ -42,6 +42,13 @@ contract InverterBeacon is IInverterBeacon, ERC165, Ownable2Step {
         _;
     }
 
+    modifier validNewMinorVersion(uint newMinorVersion) {
+        if (newMinorVersion <= minorVersion) {
+            revert Beacon__InvalidImplementationMinorVersion();
+        }
+        _;
+    }
+
     //--------------------------------------------------------------------------------
     // State
 
@@ -102,7 +109,7 @@ contract InverterBeacon is IInverterBeacon, ERC165, Ownable2Step {
         address newImplementation,
         uint newMinorVersion,
         bool overrideShutdown
-    ) public onlyOwner {
+    ) public onlyOwner validNewMinorVersion(newMinorVersion) {
         _upgradeTo(newImplementation, newMinorVersion, overrideShutdown);
     }
 

--- a/test/e2e/E2EModuleRegistry.sol
+++ b/test/e2e/E2EModuleRegistry.sol
@@ -79,7 +79,7 @@ contract E2EModuleRegistry is Test {
 
     IModule.Metadata rebasingFundingManagerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/inverter/funding-manager",
         "RebasingFundingManager"
     );
@@ -124,7 +124,7 @@ contract E2EModuleRegistry is Test {
     IModule.Metadata bancorVirtualSupplyBondingCurveFundingManagerMetadata =
     IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/inverter/bonding-curve-funding-manager",
         "BancorVirtualSupplyBondingCurveFundingManager"
     );
@@ -193,7 +193,7 @@ contract E2EModuleRegistry is Test {
     InverterBeacon roleAuthorizerBeacon;
 
     IModule.Metadata roleAuthorizerMetadata = IModule.Metadata(
-        1, 1, "https://github.com/inverter/roleAuthorizer", "RoleAuthorizer"
+        1, 0, "https://github.com/inverter/roleAuthorizer", "RoleAuthorizer"
     );
 
     /* 
@@ -231,7 +231,7 @@ contract E2EModuleRegistry is Test {
 
     IModule.Metadata tokenRoleAuthorizerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/inverter/tokenRoleAuthorizer",
         "TokenGatedRoleAuthorizer"
     );
@@ -277,7 +277,7 @@ contract E2EModuleRegistry is Test {
 
     IModule.Metadata simplePaymentProcessorMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/inverter/payment-processor",
         "SimplePaymentProcessor"
     );
@@ -317,7 +317,7 @@ contract E2EModuleRegistry is Test {
 
     IModule.Metadata streamingPaymentProcessorMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/inverter/streaming-payment-processor",
         "StreamingPaymentProcessor"
     );
@@ -360,7 +360,7 @@ contract E2EModuleRegistry is Test {
 
     IModule.Metadata recurringPaymentManagerMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/inverter/recurring-payment-manager",
         "RecurringPaymentManager"
     );
@@ -399,7 +399,7 @@ contract E2EModuleRegistry is Test {
     InverterBeacon bountyManagerBeacon;
 
     IModule.Metadata bountyManagerMetadata = IModule.Metadata(
-        1, 1, "https://github.com/inverter/bounty-manager", "BountyManager"
+        1, 0, "https://github.com/inverter/bounty-manager", "BountyManager"
     );
     /*
      IOrchestratorFactory.ModuleConfig bountyManagerFactoryConfig =
@@ -439,7 +439,7 @@ contract E2EModuleRegistry is Test {
 
     IModule.Metadata singleVoteGovernorMetadata = IModule.Metadata(
         1,
-        1,
+        0,
         "https://github.com/inverter/single-vote-governor",
         "SingleVoteGovernor"
     );
@@ -482,7 +482,7 @@ contract E2EModuleRegistry is Test {
     InverterBeacon metadataManagerBeacon;
 
     IModule.Metadata metadataManagerMetadata = IModule.Metadata(
-        1, 1, "https://github.com/inverter/metadata-manager", "MetadataManager"
+        1, 0, "https://github.com/inverter/metadata-manager", "MetadataManager"
     );
 
     function setUpMetadataManager() internal {

--- a/test/e2e/factory/InverterBeaconE2E.t.sol
+++ b/test/e2e/factory/InverterBeaconE2E.t.sol
@@ -34,7 +34,7 @@ contract InverterBeaconE2E is E2ETest {
 
     // Mock Metadata
     uint constant MAJOR_VERSION = 1;
-    uint constant MINOR_VERSION = 1;
+    uint constant MINOR_VERSION = 0;
     string constant URL = "https://github.com/organization/module";
     string constant TITLE = "Module";
 

--- a/test/factories/ModuleFactory.t.sol
+++ b/test/factories/ModuleFactory.t.sol
@@ -51,7 +51,7 @@ contract ModuleFactoryTest is Test {
 
     // Constants
     uint constant MAJOR_VERSION = 1;
-    uint constant MINOR_VERSION = 1;
+    uint constant MINOR_VERSION = 0;
     string constant URL = "https://github.com/organization/module";
     string constant TITLE = "Payment Processor";
 

--- a/test/factories/OrchestratorFactory.t.sol
+++ b/test/factories/OrchestratorFactory.t.sol
@@ -57,14 +57,14 @@ contract OrchestratorFactoryTest is Test {
 
     IOrchestratorFactory.ModuleConfig fundingManagerConfig =
     IOrchestratorFactory.ModuleConfig(
-        IModule.Metadata(1, 1, "https://fundingmanager.com", "FundingManager"),
+        IModule.Metadata(1, 0, "https://fundingmanager.com", "FundingManager"),
         bytes("data"),
         abi.encode(hasDependency, dependencies)
     );
 
     IOrchestratorFactory.ModuleConfig authorizerConfig = IOrchestratorFactory
         .ModuleConfig(
-        IModule.Metadata(1, 1, "https://authorizer.com", "Authorizer"),
+        IModule.Metadata(1, 0, "https://authorizer.com", "Authorizer"),
         abi.encode(address(this), address(this)),
         abi.encode(hasDependency, dependencies)
     );
@@ -80,7 +80,7 @@ contract OrchestratorFactoryTest is Test {
 
     IOrchestratorFactory.ModuleConfig moduleConfig = IOrchestratorFactory
         .ModuleConfig(
-        IModule.Metadata(1, 1, "https://module.com", "Module"),
+        IModule.Metadata(1, 0, "https://module.com", "Module"),
         bytes(""),
         abi.encode(hasDependency, dependencies)
     );

--- a/test/modules/ModuleTest.sol
+++ b/test/modules/ModuleTest.sol
@@ -49,7 +49,7 @@ abstract contract ModuleTest is Test {
 
     // Module Constants
     uint constant _MAJOR_VERSION = 1;
-    uint constant _MINOR_VERSION = 1;
+    uint constant _MINOR_VERSION = 0;
     string constant _URL = "https://github.com/organization/module";
     string constant _TITLE = "Module";
 

--- a/test/modules/authorizer/RoleAuthorizer.t.sol
+++ b/test/modules/authorizer/RoleAuthorizer.t.sol
@@ -55,7 +55,7 @@ contract RoleAuthorizerTest is Test {
     uint internal constant _ORCHESTRATOR_ID = 1;
     // Module Constants
     uint constant MAJOR_VERSION = 1;
-    uint constant MINOR_VERSION = 1;
+    uint constant MINOR_VERSION = 0;
     string constant URL = "https://github.com/organization/module";
     string constant TITLE = "Module";
 

--- a/test/modules/authorizer/TokenGatedRoleAuthorizer.t.sol
+++ b/test/modules/authorizer/TokenGatedRoleAuthorizer.t.sol
@@ -107,7 +107,7 @@ contract TokenGatedRoleAuthorizerTest is Test {
     uint internal constant _ORCHESTRATOR_ID = 1;
     // Module Constants
     uint constant MAJOR_VERSION = 1;
-    uint constant MINOR_VERSION = 1;
+    uint constant MINOR_VERSION = 0;
     string constant URL = "https://github.com/organization/module";
     string constant TITLE = "Module";
 


### PR DESCRIPTION
* Allows the first version of the `InverterBeacon` to be zero, which is set during `init` in the internal `_upgradeTo` function.
* Any subsequent upgrades via `upgradeTo` require the new minor version to be greater than the last one

--

Closes SC-228