### PR TITLE
Feat: Only Allow Adding of Modules Registered in the Factory

### DIFF
--- a/src/factories/IModuleFactory.sol
+++ b/src/factories/IModuleFactory.sol
@@ -66,6 +66,14 @@ interface IModuleFactory {
         view
         returns (IInverterBeacon, bytes32);
 
+    /// @notice Returns the address of the orchestrator a proxy was registered for.
+    /// @param proxy The address of the module proxy.
+    /// @return The address of the corresponding orchestrator.
+    function getOrchestratorOfProxy(address proxy)
+        external
+        view
+        returns (address);
+
     /// @notice Registers metadata `metadata` with {IInverterBeacon} implementation
     ///         `beacon`.
     /// @dev Only callable by owner.

--- a/src/orchestrator/Orchestrator.sol
+++ b/src/orchestrator/Orchestrator.sol
@@ -23,6 +23,8 @@ import {IModule} from "src/modules/base/IModule.sol";
 
 import {IModuleManager} from "src/orchestrator/base/IModuleManager.sol";
 
+import {IOrchestratorFactory} from "src/factories/IOrchestratorFactory.sol";
+
 /**
  * @title Orchestrator
  *
@@ -97,7 +99,9 @@ contract Orchestrator is IOrchestrator, ModuleManager {
         IPaymentProcessor paymentProcessor_
     ) external override(IOrchestrator) initializer {
         // Initialize upstream contracts.
-        __ModuleManager_init(modules);
+        __ModuleManager_init(
+            IOrchestratorFactory(msg.sender).moduleFactory(), modules
+        );
 
         // Set storage variables.
         orchestratorId = orchestratorId_;

--- a/src/orchestrator/base/IModuleManager.sol
+++ b/src/orchestrator/base/IModuleManager.sol
@@ -29,6 +29,9 @@ interface IModuleManager is IERC2771Context {
     /// @notice The Manager has reached the maximum amount of modules.
     error Orchestrator__ModuleManager__ModuleAmountOverLimits();
 
+    /// @notice The module has not been registered in the factory.
+    error Orchestrator__ModuleManager_ModuleNotRegisteredInFactory();
+
     //--------------------------------------------------------------------------
     // Events
 

--- a/test/modules/ModuleTest.sol
+++ b/test/modules/ModuleTest.sol
@@ -95,6 +95,22 @@ abstract contract ModuleTest is Test {
     function testReinitFails() public virtual;
 
     //--------------------------------------------------------------------------------
+    // Test: Module Manager Helpers
+    //
+    // Used to test modules without a proper factory deployment.
+    function moduleFactory() public view returns (address) {
+        return (address(this));
+    }
+
+    function getOrchestratorOfProxy(address module)
+        public
+        view
+        returns (address)
+    {
+        return msg.sender;
+    }
+
+    //--------------------------------------------------------------------------------
     // Assertion Helper Functions
     //
     // Prefixed with `_assert`.

--- a/test/orchestrator/Orchestrator.t.sol
+++ b/test/orchestrator/Orchestrator.t.sol
@@ -616,6 +616,22 @@ contract OrchestratorTest is Test {
         revert("failed");
     }
 
+    //--------------------------------------------------------------------------------
+    // Test: Module Manager Helpers
+    //
+    // Used to test the orchestrator without a proper factory deployment.
+    function moduleFactory() public view returns (address) {
+        return (address(this));
+    }
+
+    function getOrchestratorOfProxy(address module)
+        public
+        view
+        returns (address)
+    {
+        return msg.sender;
+    }
+
     //--------------------------------------------------------------------------
     // Tests: Other
 

--- a/test/orchestrator/base/ModuleManager.t.sol
+++ b/test/orchestrator/base/ModuleManager.t.sol
@@ -41,7 +41,7 @@ contract ModuleManagerTest is Test {
 
     function setUp() public {
         moduleManager = new ModuleManagerMock(address(0));
-        moduleManager.init(EMPTY_LIST);
+        moduleManager.init(address(0), EMPTY_LIST);
 
         types = new TypeSanityHelper(address(moduleManager));
 
@@ -64,9 +64,9 @@ contract ModuleManagerTest is Test {
                     .selector
             );
 
-            moduleManager.init(modules);
+            moduleManager.init(address(0), modules);
         } else {
-            moduleManager.init(modules);
+            moduleManager.init(address(0), modules);
 
             // List of modules should be size of modules array.
             address[] memory modulesAdded = moduleManager.listModules();
@@ -81,12 +81,12 @@ contract ModuleManagerTest is Test {
 
     function testReinitFails() public {
         vm.expectRevert(OZErrors.Initializable__InvalidInitialization);
-        moduleManager.init(EMPTY_LIST);
+        moduleManager.init(address(0), EMPTY_LIST);
     }
 
     function testInitFailsForNonInitializerFunction() public {
         vm.expectRevert(OZErrors.Initializable__NotInitializing);
-        moduleManager.initNoInitializer(EMPTY_LIST);
+        moduleManager.initNoInitializer(address(0), EMPTY_LIST);
     }
 
     function testInitFailsForInvalidModules() public {
@@ -105,7 +105,7 @@ contract ModuleManagerTest is Test {
                     .Orchestrator__ModuleManager__InvalidModuleAddress
                     .selector
             );
-            moduleManager.init(modules);
+            moduleManager.init(address(0), modules);
         }
     }
 
@@ -120,7 +120,7 @@ contract ModuleManagerTest is Test {
         vm.expectRevert(
             IModuleManager.Orchestrator__ModuleManager__IsModule.selector
         );
-        moduleManager.init(modules);
+        moduleManager.init(address(0), modules);
     }
 
     function testInitFailsForTooManyModules(address[] memory modules) public {
@@ -134,7 +134,7 @@ contract ModuleManagerTest is Test {
                 .Orchestrator__ModuleManager__ModuleAmountOverLimits
                 .selector
         );
-        moduleManager.init(modules);
+        moduleManager.init(address(0), modules);
     }
 
     //--------------------------------------------------------------------------

--- a/test/utils/mocks/factories/ModuleFactoryMock.sol
+++ b/test/utils/mocks/factories/ModuleFactoryMock.sol
@@ -34,6 +34,17 @@ contract ModuleFactoryMock is IModuleFactory {
         return (_beacon, LibMetadata.identifier(metadata));
     }
 
+    // For mocking purposes, we just return the callers
+    // address, as this would be the right return value
+    // from the factory, in case of a success.
+    function getOrchestratorOfProxy(address proxy)
+        external
+        view
+        returns (address)
+    {
+        return msg.sender;
+    }
+
     function registerMetadata(IModule.Metadata memory, IInverterBeacon)
         external
     {}


### PR DESCRIPTION
This adds a check to the `ModuleManager`, resulting in only being able to add modules to an Orchestrator if they are properly registered through our factory.

⚠️ The tests of this are not done yet, work in progress.