### PR TITLE
Fix: Enable Batch Role Granting from Module Base

### DIFF
--- a/src/modules/base/IModule_v1.sol
+++ b/src/modules/base/IModule_v1.sol
@@ -100,7 +100,13 @@ interface IModule_v1 {
     /// @return The module's orchestrator.
     function orchestrator() external view returns (IOrchestrator_v1);
 
-    function grantModuleRole(bytes32 role, address addr) external;
+    function grantModuleRole(bytes32 role, address target) external;
 
-    function revokeModuleRole(bytes32 role, address addr) external;
+    function grantModuleRoleBatched(bytes32 role, address[] calldata targets)
+        external;
+
+    function revokeModuleRole(bytes32 role, address target) external;
+
+    function revokeModuleRoleBatched(bytes32 role, address[] calldata targets)
+        external;
 }

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -233,20 +233,36 @@ abstract contract Module_v1 is
     //--------------------------------------------------------------------------
     // Role Management
 
-    function grantModuleRole(bytes32 role, address addr)
+    function grantModuleRole(bytes32 role, address target)
         external
         onlyOrchestratorOwner
     {
         IAuthorizer_v1 roleAuthorizer = __Module_orchestrator.authorizer();
-        roleAuthorizer.grantRoleFromModule(role, addr);
+        roleAuthorizer.grantRoleFromModule(role, target);
     }
 
-    function revokeModuleRole(bytes32 role, address addr)
+    function grantModuleRoleBatched(bytes32 role, address[] calldata targets)
         external
         onlyOrchestratorOwner
     {
         IAuthorizer_v1 roleAuthorizer = __Module_orchestrator.authorizer();
-        roleAuthorizer.revokeRoleFromModule(role, addr);
+        roleAuthorizer.grantRoleFromModuleBatched(role, targets);
+    }
+
+    function revokeModuleRole(bytes32 role, address target)
+        external
+        onlyOrchestratorOwner
+    {
+        IAuthorizer_v1 roleAuthorizer = __Module_orchestrator.authorizer();
+        roleAuthorizer.revokeRoleFromModule(role, target);
+    }
+
+    function revokeModuleRoleBatched(bytes32 role, address[] calldata targets)
+        external
+        onlyOrchestratorOwner
+    {
+        IAuthorizer_v1 roleAuthorizer = __Module_orchestrator.authorizer();
+        roleAuthorizer.revokeRoleFromModuleBatched(role, targets);
     }
 
     //--------------------------------------------------------------------------

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -92,14 +92,13 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1UpstreamTests is
         address buyer = makeAddr("buyer");
         address seller = makeAddr("seller");
 
-        bondingCurveFundingManager.grantModuleRole(
-            CURVE_INTERACTION_ROLE, buyer
-        );
-        bondingCurveFundingManager.grantModuleRole(
-            CURVE_INTERACTION_ROLE, seller
-        );
-        bondingCurveFundingManager.grantModuleRole(
-            CURVE_INTERACTION_ROLE, owner_address
+        address[] memory targets = new address[](3);
+        targets[0] = buyer;
+        targets[1] = seller;
+        targets[2] = owner_address;
+
+        bondingCurveFundingManager.grantModuleRoleBatched(
+            CURVE_INTERACTION_ROLE, targets
         );
     }
 

--- a/test/utils/mocks/modules/AuthorizerV1Mock.sol
+++ b/test/utils/mocks/modules/AuthorizerV1Mock.sol
@@ -80,8 +80,28 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
         _roleAuthorized[generateRoleId(_msgSender(), role)][target] = true;
     }
 
+    function grantRoleFromModuleBatched(
+        bytes32 role,
+        address[] calldata targets
+    ) external {
+        for (uint i = 0; i < targets.length; i++) {
+            _roleAuthorized[generateRoleId(_msgSender(), role)][targets[i]] =
+                true;
+        }
+    }
+
     function revokeRoleFromModule(bytes32 role, address target) external {
         _roleAuthorized[generateRoleId(_msgSender(), role)][target] = false;
+    }
+
+    function revokeRoleFromModuleBatched(
+        bytes32 role,
+        address[] calldata targets
+    ) external {
+        for (uint i = 0; i < targets.length; i++) {
+            _roleAuthorized[generateRoleId(_msgSender(), role)][targets[i]] =
+                false;
+        }
     }
 
     function grantRole(bytes32 role, address who) public {
@@ -134,20 +154,6 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
 
     //--------------------------------------------------------------------------
     // Functions left empty
-
-    function grantRoleFromModuleBatched(bytes32, address[] calldata)
-        external
-        pure
-    {
-        revert("Not implemented in Authorizer Mock");
-    }
-
-    function revokeRoleFromModuleBatched(bytes32, address[] calldata)
-        external
-        pure
-    {
-        revert("Not implemented in Authorizer Mock");
-    }
 
     function grantGlobalRoleBatched(bytes32, address[] calldata)
         external


### PR DESCRIPTION
The implementation of batch-granting and -revoking of roles (in this case module roles), didn't include to enable this functionality in the `Module` base contract, from where it needs to be used (as the `Authorizer` function itself is `onlyModule`). 

This PR adds this functionality and extends the tests to cover it properly.

-- 

Solves SC-278