### PR TITLE
[SC-296] Audit(H-2): Set BURN_ADMIN_ROLE during initialization

### DIFF
--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -81,12 +81,7 @@ contract AUT_Roles_v1 is
     }
 
     //--------------------------------------------------------------------------
-    // Constructor and initialization
-
-    constructor() {
-        // make the BURN_ADMIN_ROLE immutable
-        _setRoleAdmin(BURN_ADMIN_ROLE, BURN_ADMIN_ROLE);
-    }
+    // Initialization
 
     /// @inheritdoc Module_v1
     function init(
@@ -109,6 +104,9 @@ contract AUT_Roles_v1 is
         // Note about DEFAULT_ADMIN_ROLE: The DEFAULT_ADMIN_ROLE has admin privileges on all roles in the contract. It starts out empty, but we set the orchestrator owners as "admins of the admin role",
         // so they can whitelist an address which then will have full write access to the roles in the system. This is mainly intended for safety/recovery situations,
         // Modules can opt out of this on a per-role basis by setting the admin role to "BURN_ADMIN_ROLE".
+
+        // make the BURN_ADMIN_ROLE immutable
+        _setRoleAdmin(BURN_ADMIN_ROLE, BURN_ADMIN_ROLE);
 
         // Set up OWNER role structure:
 

--- a/test/modules/authorizer/role/AUT_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_Roles_v1.t.sol
@@ -167,6 +167,11 @@ contract AUT_RolesV1Test is Test {
             abi.encode(initialAuth, address(this))
         );
 
+        assertEq(
+            testAuthorizer.getRoleAdmin(testAuthorizer.BURN_ADMIN_ROLE()),
+            testAuthorizer.BURN_ADMIN_ROLE()
+        );
+
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
         assertEq(testAuthorizer.hasRole("0x01", initialAuth), true);
@@ -192,6 +197,11 @@ contract AUT_RolesV1Test is Test {
             abi.encode(initialAuth, address(this))
         );
 
+        assertEq(
+            testAuthorizer.getRoleAdmin(testAuthorizer.BURN_ADMIN_ROLE()),
+            testAuthorizer.BURN_ADMIN_ROLE()
+        );
+
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
         assertEq(testAuthorizer.hasRole("0x01", address(this)), true);
@@ -213,6 +223,11 @@ contract AUT_RolesV1Test is Test {
             IOrchestrator_v1(_orchestrator),
             _METADATA,
             abi.encode(initialAuth, address(this))
+        );
+
+        assertEq(
+            testAuthorizer.getRoleAdmin(testAuthorizer.BURN_ADMIN_ROLE()),
+            testAuthorizer.BURN_ADMIN_ROLE()
         );
 
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));


### PR DESCRIPTION
## What has been done
- Moved `_setRoleAdmin(BURN_ADMIN_ROLE, BURN_ADMIN_ROLE);`to the initialization function
- Added check to the tests

Closes [SC-296]