### PR TITLE
[SC-295] Audit(H-1): add storage slot gaps to layout

### DIFF
--- a/src/external/fees/FeeManager_v1.sol
+++ b/src/external/fees/FeeManager_v1.sol
@@ -70,6 +70,9 @@ contract FeeManager_v1 is ERC165, IFeeManager_v1, Ownable2StepUpgradeable {
     mapping(address => mapping(bytes32 => Fee)) internal workflowIssuanceFees;
     mapping(address => mapping(bytes32 => Fee)) internal workflowCollateralFees;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/external/fees/FeeManager_v1.sol
+++ b/src/external/fees/FeeManager_v1.sol
@@ -71,7 +71,7 @@ contract FeeManager_v1 is ERC165, IFeeManager_v1, Ownable2StepUpgradeable {
     mapping(address => mapping(bytes32 => Fee)) internal workflowCollateralFees;
 
     // Storage gap for future upgrades
-    uint[50] __gap_feeManager;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/external/fees/FeeManager_v1.sol
+++ b/src/external/fees/FeeManager_v1.sol
@@ -71,7 +71,7 @@ contract FeeManager_v1 is ERC165, IFeeManager_v1, Ownable2StepUpgradeable {
     mapping(address => mapping(bytes32 => Fee)) internal workflowCollateralFees;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_feeManager;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/external/forwarder/TransactionForwarder_v1.sol
+++ b/src/external/forwarder/TransactionForwarder_v1.sol
@@ -31,6 +31,9 @@ contract TransactionForwarder_v1 is
     ERC2771Forwarder,
     Context
 {
+    // Storage gap for future upgrades
+    uint[50] private __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -109,7 +109,7 @@ contract Governor_v1 is ERC165, IGovernor_v1, AccessControlUpgradeable {
     mapping(address => IGovernor_v1.Timelock) private beaconTimelock;
 
     // Storage gap for future upgrades
-    uint[50] __gap_Governor;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -108,6 +108,9 @@ contract Governor_v1 is ERC165, IGovernor_v1, AccessControlUpgradeable {
 
     mapping(address => IGovernor_v1.Timelock) private beaconTimelock;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -109,7 +109,7 @@ contract Governor_v1 is ERC165, IGovernor_v1, AccessControlUpgradeable {
     mapping(address => IGovernor_v1.Timelock) private beaconTimelock;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_Governor;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -94,6 +94,9 @@ contract ModuleFactory_v1 is
     /// @dev MetadataLib.identifier(metadata) => {IInverterBeacon_v1}
     mapping(bytes32 => IInverterBeacon_v1) private _beacons;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Constructor & Initializer
 

--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -95,7 +95,7 @@ contract ModuleFactory_v1 is
     mapping(bytes32 => IInverterBeacon_v1) private _beacons;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_ModuleFactory;
 
     //--------------------------------------------------------------------------
     // Constructor & Initializer

--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -95,7 +95,7 @@ contract ModuleFactory_v1 is
     mapping(bytes32 => IInverterBeacon_v1) private _beacons;
 
     // Storage gap for future upgrades
-    uint[50] __gap_ModuleFactory;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Constructor & Initializer

--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -79,6 +79,9 @@ contract OrchestratorFactory_v1 is
     /// @dev Starts counting from 1.
     uint private _orchestratorIdCounter;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------------
     // Modifier
 

--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -80,7 +80,7 @@ contract OrchestratorFactory_v1 is
     uint private _orchestratorIdCounter;
 
     // Storage gap for future upgrades
-    uint[50] __gap_OrchestratorFactory;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------------
     // Modifier

--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -80,7 +80,7 @@ contract OrchestratorFactory_v1 is
     uint private _orchestratorIdCounter;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_OrchestratorFactory;
 
     //--------------------------------------------------------------------------------
     // Modifier

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -58,6 +58,9 @@ contract AUT_Roles_v1 is
     bytes32 public constant BURN_ADMIN_ROLE =
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Modifiers
 

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -59,7 +59,7 @@ contract AUT_Roles_v1 is
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_Roles;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -59,7 +59,7 @@ contract AUT_Roles_v1 is
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
     // Storage gap for future upgrades
-    uint[50] __gap_Roles;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -89,6 +89,9 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     // Stores the threshold amount for each token in a role
     mapping(bytes32 => uint) public thresholdMap;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Overloaded and overriden functions
 

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -90,7 +90,7 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     mapping(bytes32 => uint) public thresholdMap;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_tokenRoles;
 
     //--------------------------------------------------------------------------
     // Overloaded and overriden functions

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -90,7 +90,7 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     mapping(bytes32 => uint) public thresholdMap;
 
     // Storage gap for future upgrades
-    uint[50] __gap_tokenRoles;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Overloaded and overriden functions

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -73,7 +73,7 @@ abstract contract Module_v1 is
     Metadata internal __Module_metadata;
 
     // Storage gap for future upgrades
-    uint[50] __gap_Module;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -73,7 +73,7 @@ abstract contract Module_v1 is
     Metadata internal __Module_metadata;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_Module;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -72,6 +72,9 @@ abstract contract Module_v1 is
     /// @custom:invariant Not mutated after initialization.
     Metadata internal __Module_metadata;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Modifiers
     //

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -103,6 +103,9 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
     /// @dev Token decimals of the issuance token, which is stored within the implementation for gas saving.
     uint8 internal issuanceTokenDecimals;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Init Function
 

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -104,7 +104,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
     uint8 internal issuanceTokenDecimals;
 
     // Storage gap for future upgrades
-    uint[50] __gap_BancorRedeemingVirtualSupply;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Init Function

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -104,7 +104,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
     uint8 internal issuanceTokenDecimals;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_BancorRedeemingVirtualSupply;
 
     //--------------------------------------------------------------------------
     // Init Function

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -46,6 +46,9 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1 is
     //Minter/Burner Role
     bytes32 public constant CURVE_INTERACTION_ROLE = "CURVE_USER";
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Public Functions
 

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -47,7 +47,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1 is
     bytes32 public constant CURVE_INTERACTION_ROLE = "CURVE_USER";
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_RestrictedBancorRedeemingVirtualSupply;
 
     //--------------------------------------------------------------------------
     // Public Functions

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -47,7 +47,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1 is
     bytes32 public constant CURVE_INTERACTION_ROLE = "CURVE_USER";
 
     // Storage gap for future upgrades
-    uint[50] __gap_RestrictedBancorRedeemingVirtualSupply;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Public Functions

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -61,9 +61,8 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     /// when engaging with the bonding curve-based funding manager. Collected in collateral
     uint public projectCollateralFeeCollected;
 
-        // Storage gap for future upgrades
+    // Storage gap for future upgrades
     uint[50] __gap;
-
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -62,7 +62,7 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     uint public projectCollateralFeeCollected;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_BondingCurveBase;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -61,6 +61,10 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     /// when engaging with the bonding curve-based funding manager. Collected in collateral
     uint public projectCollateralFeeCollected;
 
+        // Storage gap for future upgrades
+    uint[50] __gap;
+
+
     //--------------------------------------------------------------------------
     // Modifiers
 

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -62,7 +62,7 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     uint public projectCollateralFeeCollected;
 
     // Storage gap for future upgrades
-    uint[50] __gap_BondingCurveBase;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -55,7 +55,7 @@ abstract contract RedeemingBondingCurveBase_v1 is
     uint public sellFee;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_RedeemingBondingCurveBase;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -54,6 +54,9 @@ abstract contract RedeemingBondingCurveBase_v1 is
     /// @dev Sell fee expressed in base points, i.e. 0% = 0; 1% = 100; 10% = 1000
     uint public sellFee;
 
+        // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Modifiers
 

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -55,7 +55,7 @@ abstract contract RedeemingBondingCurveBase_v1 is
     uint public sellFee;
 
     // Storage gap for future upgrades
-    uint[50] __gap_RedeemingBondingCurveBase;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -54,7 +54,7 @@ abstract contract RedeemingBondingCurveBase_v1 is
     /// @dev Sell fee expressed in base points, i.e. 0% = 0; 1% = 100; 10% = 1000
     uint public sellFee;
 
-        // Storage gap for future upgrades
+    // Storage gap for future upgrades
     uint[50] __gap;
 
     //--------------------------------------------------------------------------

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
@@ -45,7 +45,7 @@ abstract contract VirtualCollateralSupplyBase_v1 is
     uint private constant MAX_UINT = type(uint).max;
 
     // Storage gap for future upgrades
-    uint[50] __gap_VirtualCollateralSupply;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Public Functions

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
@@ -44,6 +44,9 @@ abstract contract VirtualCollateralSupplyBase_v1 is
     /// @dev Maximum unsigned integer value for overflow checks.
     uint private constant MAX_UINT = type(uint).max;
 
+        // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Public Functions
     /// @inheritdoc IVirtualCollateralSupplyBase_v1

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
@@ -44,7 +44,7 @@ abstract contract VirtualCollateralSupplyBase_v1 is
     /// @dev Maximum unsigned integer value for overflow checks.
     uint private constant MAX_UINT = type(uint).max;
 
-        // Storage gap for future upgrades
+    // Storage gap for future upgrades
     uint[50] __gap;
 
     //--------------------------------------------------------------------------

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualCollateralSupplyBase_v1.sol
@@ -45,7 +45,7 @@ abstract contract VirtualCollateralSupplyBase_v1 is
     uint private constant MAX_UINT = type(uint).max;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_VirtualCollateralSupply;
 
     //--------------------------------------------------------------------------
     // Public Functions

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
@@ -44,6 +44,9 @@ abstract contract VirtualIssuanceSupplyBase_v1 is
     /// @dev Maximum unsigned integer value for overflow checks.
     uint private constant MAX_UINT = type(uint).max;
 
+        // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Public Functions
 

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
@@ -45,7 +45,7 @@ abstract contract VirtualIssuanceSupplyBase_v1 is
     uint private constant MAX_UINT = type(uint).max;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_VirtualIssuanceSupply;
 
     //--------------------------------------------------------------------------
     // Public Functions

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
@@ -45,7 +45,7 @@ abstract contract VirtualIssuanceSupplyBase_v1 is
     uint private constant MAX_UINT = type(uint).max;
 
     // Storage gap for future upgrades
-    uint[50] __gap_VirtualIssuanceSupply;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Public Functions

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
@@ -44,7 +44,7 @@ abstract contract VirtualIssuanceSupplyBase_v1 is
     /// @dev Maximum unsigned integer value for overflow checks.
     uint private constant MAX_UINT = type(uint).max;
 
-        // Storage gap for future upgrades
+    // Storage gap for future upgrades
     uint[50] __gap;
 
     //--------------------------------------------------------------------------

--- a/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
+++ b/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
@@ -81,7 +81,7 @@ contract FM_Rebasing_v1 is
     IERC20 private _token;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_RebasingFM;
 
     //--------------------------------------------------------------------------
     // Init Function

--- a/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
+++ b/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
@@ -80,6 +80,9 @@ contract FM_Rebasing_v1 is
 
     IERC20 private _token;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Init Function
 

--- a/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
+++ b/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
@@ -81,7 +81,7 @@ contract FM_Rebasing_v1 is
     IERC20 private _token;
 
     // Storage gap for future upgrades
-    uint[50] __gap_RebasingFM;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Init Function

--- a/src/modules/fundingManager/rebasing/abstracts/ElasticReceiptTokenUpgradeable_v1.sol
+++ b/src/modules/fundingManager/rebasing/abstracts/ElasticReceiptTokenUpgradeable_v1.sol
@@ -19,7 +19,6 @@ import {ElasticReceiptTokenBase_v1} from
 abstract contract ElasticReceiptTokenUpgradeable_v1 is
     ElasticReceiptTokenBase_v1
 {
-
     // Storage gap for future upgrades
     uint[50] private __gap;
 

--- a/src/modules/fundingManager/rebasing/abstracts/ElasticReceiptTokenUpgradeable_v1.sol
+++ b/src/modules/fundingManager/rebasing/abstracts/ElasticReceiptTokenUpgradeable_v1.sol
@@ -19,6 +19,10 @@ import {ElasticReceiptTokenBase_v1} from
 abstract contract ElasticReceiptTokenUpgradeable_v1 is
     ElasticReceiptTokenBase_v1
 {
+
+    // Storage gap for future upgrades
+    uint[50] private __gap;
+
     function supportsInterface(bytes4 interfaceId)
         public
         view

--- a/src/modules/logicModule/LM_PC_Bounties_v1.sol
+++ b/src/modules/logicModule/LM_PC_Bounties_v1.sol
@@ -212,6 +212,10 @@ contract LM_PC_Bounties_v1 is ILM_PC_Bounties_v1, ERC20PaymentClientBase_v1 {
 
     //@dev Connects contributor addresses to claim Ids
     mapping(address => EnumerableSet.UintSet) contributorAddressToClaimIds;
+
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/modules/logicModule/LM_PC_Bounties_v1.sol
+++ b/src/modules/logicModule/LM_PC_Bounties_v1.sol
@@ -214,7 +214,7 @@ contract LM_PC_Bounties_v1 is ILM_PC_Bounties_v1, ERC20PaymentClientBase_v1 {
     mapping(address => EnumerableSet.UintSet) contributorAddressToClaimIds;
 
     // Storage gap for future upgrades
-    uint[50] __gap_Bounties;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/logicModule/LM_PC_Bounties_v1.sol
+++ b/src/modules/logicModule/LM_PC_Bounties_v1.sol
@@ -214,7 +214,7 @@ contract LM_PC_Bounties_v1 is ILM_PC_Bounties_v1, ERC20PaymentClientBase_v1 {
     mapping(address => EnumerableSet.UintSet) contributorAddressToClaimIds;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_Bounties;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -67,7 +67,7 @@ contract LM_PC_KPIRewarder_v1 is
     uint public constant MAX_QUEUE_LENGTH = 50;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_KPIRewarder;
 
     /*
     Tranche Example:

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -66,6 +66,9 @@ contract LM_PC_KPIRewarder_v1 is
     uint public totalQueuedFunds;
     uint public constant MAX_QUEUE_LENGTH = 50;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     /*
     Tranche Example:
     trancheValues = [10000, 20000, 30000]

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -67,7 +67,7 @@ contract LM_PC_KPIRewarder_v1 is
     uint public constant MAX_QUEUE_LENGTH = 50;
 
     // Storage gap for future upgrades
-    uint[50] __gap_KPIRewarder;
+    uint[50] private __gap;
 
     /*
     Tranche Example:

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -98,7 +98,7 @@ contract LM_PC_RecurringPayments_v1 is
     LinkedIdList.List _paymentList;
 
     // Storage gap for future upgrades
-    uint[50] __gap_RecurringPayments;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -98,7 +98,7 @@ contract LM_PC_RecurringPayments_v1 is
     LinkedIdList.List _paymentList;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_RecurringPayments;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -97,6 +97,9 @@ contract LM_PC_RecurringPayments_v1 is
     /// @dev List of RecurringPayment id's.
     LinkedIdList.List _paymentList;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -65,7 +65,7 @@ contract LM_PC_Staking_v1 is
     mapping(address => uint) internal rewards;
 
     // Storage gap for future upgrades
-    uint[50] _Staking;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -64,6 +64,9 @@ contract LM_PC_Staking_v1 is
     /// @dev mapping of how many reward tokens the user accumulated
     mapping(address => uint) internal rewards;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -65,7 +65,7 @@ contract LM_PC_Staking_v1 is
     mapping(address => uint) internal rewards;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] _Staking;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
@@ -73,6 +73,9 @@ abstract contract ERC20PaymentClientBase_v1 is
     /// @dev The current cumulative amount of tokens outstanding.
     uint internal _outstandingTokenAmount;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Internal Mutating Functions
 

--- a/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
@@ -74,7 +74,7 @@ abstract contract ERC20PaymentClientBase_v1 is
     uint internal _outstandingTokenAmount;
 
     // Storage gap for future upgrades
-    uint[50] __gap_ERC20PaymentClientBase;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Internal Mutating Functions

--- a/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
@@ -74,7 +74,7 @@ abstract contract ERC20PaymentClientBase_v1 is
     uint internal _outstandingTokenAmount;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_ERC20PaymentClientBase;
 
     //--------------------------------------------------------------------------
     // Internal Mutating Functions

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -48,7 +48,7 @@ abstract contract OptimisticOracleIntegrator is
     mapping(bytes32 => DataAssertion) public assertionData;
 
     // Storage gap for future upgrades
-    uint[50] __gap_OptimisticOracleIntegrator;
+    uint[50] private __gap;
 
     //==========================================================================
     // Initialization

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -47,6 +47,9 @@ abstract contract OptimisticOracleIntegrator is
     // Assertion storage
     mapping(bytes32 => DataAssertion) public assertionData;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //==========================================================================
     // Initialization
 

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -48,7 +48,7 @@ abstract contract OptimisticOracleIntegrator is
     mapping(bytes32 => DataAssertion) public assertionData;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_OptimisticOracleIntegrator;
 
     //==========================================================================
     // Initialization

--- a/src/modules/paymentProcessor/PP_Simple_v1.sol
+++ b/src/modules/paymentProcessor/PP_Simple_v1.sol
@@ -76,7 +76,7 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
 
     //--------------------------------------------------------------------------
     // Initialization
-    
+
     /// @inheritdoc Module_v1
     function init(
         IOrchestrator_v1 orchestrator_,

--- a/src/modules/paymentProcessor/PP_Simple_v1.sol
+++ b/src/modules/paymentProcessor/PP_Simple_v1.sol
@@ -67,7 +67,7 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
     // Storage
 
     // Gap for possible future upgrades
-    uint[50] __gap;
+    uint[50] __gap_SimplePP;
 
     /// @inheritdoc Module_v1
     function init(

--- a/src/modules/paymentProcessor/PP_Simple_v1.sol
+++ b/src/modules/paymentProcessor/PP_Simple_v1.sol
@@ -63,6 +63,12 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
         _;
     }
 
+    //--------------------------------------------------------------------------
+    // Storage
+
+    // Gap for possible future upgrades
+    uint[50] __gap;
+
     /// @inheritdoc Module_v1
     function init(
         IOrchestrator_v1 orchestrator_,

--- a/src/modules/paymentProcessor/PP_Simple_v1.sol
+++ b/src/modules/paymentProcessor/PP_Simple_v1.sol
@@ -67,7 +67,7 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
     // Storage
 
     // Gap for possible future upgrades
-    uint[50] __gap_SimplePP;
+    uint[50] private __gap;
 
     /// @inheritdoc Module_v1
     function init(

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -80,7 +80,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     mapping(address => mapping(address => uint[])) private activeVestingWallets;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_StreamingPP;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -79,6 +79,9 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     /// @dev client => paymentReceiver => arrayOfWalletIdsWithPendingPayment(uint[])
     mapping(address => mapping(address => uint[])) private activeVestingWallets;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Modifiers
 

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -80,7 +80,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     mapping(address => mapping(address => uint[])) private activeVestingWallets;
 
     // Storage gap for future upgrades
-    uint[50] __gap_StreamingPP;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Modifiers

--- a/src/modules/utils/MetadataManager_v1.sol
+++ b/src/modules/utils/MetadataManager_v1.sol
@@ -43,6 +43,9 @@ contract MetadataManager_v1 is IMetadataManager_v1, Module_v1 {
     OrchestratorMetadata private _orchestratorMetadata;
     MemberMetadata[] private _teamMetadata;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/modules/utils/MetadataManager_v1.sol
+++ b/src/modules/utils/MetadataManager_v1.sol
@@ -44,7 +44,7 @@ contract MetadataManager_v1 is IMetadataManager_v1, Module_v1 {
     MemberMetadata[] private _teamMetadata;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_MetadataManager;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/utils/MetadataManager_v1.sol
+++ b/src/modules/utils/MetadataManager_v1.sol
@@ -44,7 +44,7 @@ contract MetadataManager_v1 is IMetadataManager_v1, Module_v1 {
     MemberMetadata[] private _teamMetadata;
 
     // Storage gap for future upgrades
-    uint[50] __gap_MetadataManager;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/utils/VotingRoleManager_v1.sol
+++ b/src/modules/utils/VotingRoleManager_v1.sol
@@ -94,7 +94,7 @@ contract VotingRoleManager_v1 is IVotingRoleManager_v1, Module_v1 {
     uint public voteDuration;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_VotingRoleManager;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/modules/utils/VotingRoleManager_v1.sol
+++ b/src/modules/utils/VotingRoleManager_v1.sol
@@ -93,6 +93,9 @@ contract VotingRoleManager_v1 is IVotingRoleManager_v1, Module_v1 {
     /// @inheritdoc IVotingRoleManager_v1
     uint public voteDuration;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initialization
 

--- a/src/modules/utils/VotingRoleManager_v1.sol
+++ b/src/modules/utils/VotingRoleManager_v1.sol
@@ -94,7 +94,7 @@ contract VotingRoleManager_v1 is IVotingRoleManager_v1, Module_v1 {
     uint public voteDuration;
 
     // Storage gap for future upgrades
-    uint[50] __gap_VotingRoleManager;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initialization

--- a/src/orchestrator/Orchestrator_v1.sol
+++ b/src/orchestrator/Orchestrator_v1.sol
@@ -104,7 +104,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     IGovernor_v1 public override(IOrchestrator_v1) governor;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
+    uint[50] __gap_Orchestrator;
 
     //--------------------------------------------------------------------------
     // Initializer

--- a/src/orchestrator/Orchestrator_v1.sol
+++ b/src/orchestrator/Orchestrator_v1.sol
@@ -104,7 +104,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     IGovernor_v1 public override(IOrchestrator_v1) governor;
 
     // Storage gap for future upgrades
-    uint[50] __gap_Orchestrator;
+    uint[50] private __gap;
 
     //--------------------------------------------------------------------------
     // Initializer

--- a/src/orchestrator/Orchestrator_v1.sol
+++ b/src/orchestrator/Orchestrator_v1.sol
@@ -103,6 +103,9 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     IGovernor_v1 public override(IOrchestrator_v1) governor;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+
     //--------------------------------------------------------------------------
     // Initializer
 

--- a/src/orchestrator/abstracts/ModuleManagerBase_v1.sol
+++ b/src/orchestrator/abstracts/ModuleManagerBase_v1.sol
@@ -119,6 +119,9 @@ abstract contract ModuleManagerBase_v1 is
     mapping(address module => ModuleUpdateTimelock timelock) public
         moduleAddressToTimelock;
 
+    // Storage gap for future upgrades
+    uint[50] __gap;
+    
     //--------------------------------------------------------------------------
     // Initializer
 

--- a/src/orchestrator/abstracts/ModuleManagerBase_v1.sol
+++ b/src/orchestrator/abstracts/ModuleManagerBase_v1.sol
@@ -120,8 +120,8 @@ abstract contract ModuleManagerBase_v1 is
         moduleAddressToTimelock;
 
     // Storage gap for future upgrades
-    uint[50] __gap;
-    
+    uint[50] private __gap;
+
     //--------------------------------------------------------------------------
     // Initializer
 


### PR DESCRIPTION
## What has been done
Added a storage gap to all upgradeable modules.

## Open question
I also added gaps to non-upgradeable abstract contracts if they are going to be inherited by upgradeable ones. This specifically applies to the Bonding Curve contracts, where the Base contracts don't inherit from Module_v1. I'd be thankful for a double-check in that department.
