### PR TITLE
Feat: Only Allow Adding of Modules Registered in the Factory

### DIFF
--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -167,6 +167,7 @@ contract OrchestratorFactory_v1 is
         // Initialize orchestrator.
         IOrchestrator_v1(clone).init(
             _orchestratorIdCounter,
+            moduleFactory,
             modules,
             IFundingManager_v1(fundingManager),
             IAuthorizer_v1(authorizer),

--- a/src/factories/interfaces/IModuleFactory_v1.sol
+++ b/src/factories/interfaces/IModuleFactory_v1.sol
@@ -66,6 +66,14 @@ interface IModuleFactory_v1 {
         view
         returns (IInverterBeacon_v1, bytes32);
 
+    /// @notice Returns the orchestrator address of a beacon proxy.
+    /// @param proxy The beacon proxy address.
+    /// @return The corresponding orchestrator address for the provided proxy.
+    function getOrchestratorOfProxy(address proxy)
+        external
+        view
+        returns (address);
+
     /// @notice Registers metadata `metadata` with {IInverterBeacon_v1} implementation
     ///         `beacon`.
     /// @dev Only callable by owner.

--- a/src/orchestrator/Orchestrator_v1.sol
+++ b/src/orchestrator/Orchestrator_v1.sol
@@ -99,6 +99,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function init(
         uint orchestratorId_,
+        address moduleFactory_,
         address[] calldata modules,
         IFundingManager_v1 fundingManager_,
         IAuthorizer_v1 authorizer_,
@@ -106,7 +107,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
         IGovernor_v1 governor_
     ) external override(IOrchestrator_v1) initializer {
         // Initialize upstream contracts.
-        __ModuleManager_init(modules);
+        __ModuleManager_init(moduleFactory_, modules);
 
         // Set storage variables.
         orchestratorId = orchestratorId_;

--- a/src/orchestrator/interfaces/IModuleManagerBase_v1.sol
+++ b/src/orchestrator/interfaces/IModuleManagerBase_v1.sol
@@ -48,6 +48,12 @@ interface IModuleManagerBase_v1 is IERC2771Context {
     /// @notice Module update is already in progress.
     error ModuleManagerBase__ModuleUpdateAlreadyStarted();
 
+    /// @notice Module has not bee registered in our factory.
+    error ModuleManagerBase__ModuleNotRegistered();
+
+    /// @notice Referenced Module Factory is invalid.
+    error ModuleManagerBase__ModuleFactoryInvalid();
+
     //--------------------------------------------------------------------------
     // Events
 

--- a/src/orchestrator/interfaces/IOrchestrator_v1.sol
+++ b/src/orchestrator/interfaces/IOrchestrator_v1.sol
@@ -75,6 +75,7 @@ interface IOrchestrator_v1 is IModuleManagerBase_v1 {
     /// @notice Initialization function.
     function init(
         uint orchestratorId,
+        address moduleFactory_,
         address[] calldata modules,
         IFundingManager_v1 fundingManager,
         IAuthorizer_v1 authorizer,

--- a/test/e2e/orchestrator_and_structural/OrchestratorE2E.sol
+++ b/test/e2e/orchestrator_and_structural/OrchestratorE2E.sol
@@ -75,7 +75,7 @@ contract OrchestratorE2E is E2ETest {
     }
 
     //We're adding and removing a Module during the lifetime of the orchestrator
-    function testManageModulesLiveOnPorposal() public {
+    function testManageModulesLiveOnOrchestrator() public {
         // address(this) creates a new orchestrator.
         IOrchestratorFactory_v1.OrchestratorConfig memory orchestratorConfig =
         IOrchestratorFactory_v1.OrchestratorConfig({

--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -199,8 +199,10 @@ contract ModuleFactoryV1Test is Test {
                 metadata, IOrchestrator_v1(orchestrator), configData
             )
         );
-        
-        assertEq(factory.getOrchestratorOfProxy(address(newModule)), orchestrator);
+
+        assertEq(
+            factory.getOrchestratorOfProxy(address(newModule)), orchestrator
+        );
         assertEq(address(newModule.orchestrator()), address(orchestrator));
         assertEq(newModule.identifier(), LibMetadata.identifier(metadata));
     }

--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -199,7 +199,8 @@ contract ModuleFactoryV1Test is Test {
                 metadata, IOrchestrator_v1(orchestrator), configData
             )
         );
-
+        
+        assertEq(factory.getOrchestratorOfProxy(address(newModule)), orchestrator);
         assertEq(address(newModule.orchestrator()), address(orchestrator));
         assertEq(newModule.identifier(), LibMetadata.identifier(metadata));
     }

--- a/test/modules/ModuleTest.sol
+++ b/test/modules/ModuleTest.sol
@@ -16,6 +16,8 @@ import {FeeManager_v1} from "src/external/fees/FeeManager_v1.sol";
 import {GovernorV1Mock} from "test/utils/mocks/external/GovernorV1Mock.sol";
 import {TransactionForwarder_v1} from
     "src/external/forwarder/TransactionForwarder_v1.sol";
+import {ModuleFactoryV1Mock} from
+    "test/utils/mocks/factories/ModuleFactoryV1Mock.sol";
 
 // Internal Interfaces
 import {IModule_v1, IOrchestrator_v1} from "src/modules/base/IModule_v1.sol";
@@ -43,6 +45,7 @@ abstract contract ModuleTest is Test {
     PaymentProcessorV1Mock _paymentProcessor = new PaymentProcessorV1Mock();
 
     GovernorV1Mock governor = new GovernorV1Mock();
+    ModuleFactoryV1Mock moduleFactory = new ModuleFactoryV1Mock();
 
     FeeManager_v1 feeManager;
     address treasury = makeAddr("treasury");
@@ -84,6 +87,7 @@ abstract contract ModuleTest is Test {
 
         _orchestrator.init(
             _ORCHESTRATOR_ID,
+            address(moduleFactory),
             modules,
             _fundingManager,
             _authorizer,

--- a/test/modules/authorizer/role/AUT_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_Roles_v1.t.sol
@@ -33,6 +33,8 @@ import {FundingManagerV1Mock} from
 import {PaymentProcessorV1Mock} from
     "test/utils/mocks/modules/PaymentProcessorV1Mock.sol";
 import {GovernorV1Mock} from "test/utils/mocks/external/GovernorV1Mock.sol";
+import {ModuleFactoryV1Mock} from
+    "test/utils/mocks/factories/ModuleFactoryV1Mock.sol";
 
 contract AUT_RolesV1Test is Test {
     // Mocks
@@ -41,7 +43,8 @@ contract AUT_RolesV1Test is Test {
     ERC20Mock internal _token = new ERC20Mock("Mock Token", "MOCK");
     FundingManagerV1Mock _fundingManager = new FundingManagerV1Mock();
     PaymentProcessorV1Mock _paymentProcessor = new PaymentProcessorV1Mock();
-    GovernorV1Mock internal governor = new GovernorV1Mock();
+    GovernorV1Mock internal _governor = new GovernorV1Mock();
+    ModuleFactoryV1Mock internal _moduleFactory = new ModuleFactoryV1Mock();
     TransactionForwarder_v1 _forwarder =
         new TransactionForwarder_v1("TransactionForwarder_v1");
     address ALBA = address(0xa1ba); //default authorized person
@@ -109,11 +112,12 @@ contract AUT_RolesV1Test is Test {
         modules[0] = address(module);
         _orchestrator.init(
             _ORCHESTRATOR_ID,
+            address(_moduleFactory),
             modules,
             _fundingManager,
             _authorizer,
             _paymentProcessor,
-            governor
+            _governor
         );
 
         address initialAuth = ALBA;

--- a/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
@@ -34,6 +34,8 @@ import {FundingManagerV1Mock} from
 import {PaymentProcessorV1Mock} from
     "test/utils/mocks/modules/PaymentProcessorV1Mock.sol";
 import {GovernorV1Mock} from "test/utils/mocks/external/GovernorV1Mock.sol";
+import {ModuleFactoryV1Mock} from
+    "test/utils/mocks/factories/ModuleFactoryV1Mock.sol";
 
 // Run through the AUT_Roles_v1 tests with the AUT_TokenGated_Roles_v1
 contract AUT_TokenGated_RolesV1Test is AUT_RolesV1Test {
@@ -50,11 +52,12 @@ contract AUT_TokenGated_RolesV1Test is AUT_RolesV1Test {
         modules[0] = address(module);
         _orchestrator.init(
             _ORCHESTRATOR_ID,
+            address(_moduleFactory),
             modules,
             _fundingManager,
             _authorizer,
             _paymentProcessor,
-            governor
+            _governor
         );
 
         address initialAuth = ALBA;
@@ -84,7 +87,8 @@ contract TokenGatedAUT_RoleV1Test is Test {
     ERC20Mock internal _token = new ERC20Mock("Mock Token", "MOCK");
     FundingManagerV1Mock _fundingManager = new FundingManagerV1Mock();
     PaymentProcessorV1Mock _paymentProcessor = new PaymentProcessorV1Mock();
-    GovernorV1Mock internal governor = new GovernorV1Mock();
+    GovernorV1Mock internal _governor = new GovernorV1Mock();
+    ModuleFactoryV1Mock internal _moduleFactory = new ModuleFactoryV1Mock();
 
     ModuleV1Mock mockModule = new ModuleV1Mock();
 
@@ -134,11 +138,12 @@ contract TokenGatedAUT_RoleV1Test is Test {
         modules[0] = address(mockModule);
         _orchestrator.init(
             _ORCHESTRATOR_ID,
+            address(_moduleFactory),
             modules,
             _fundingManager,
             _authorizer,
             _paymentProcessor,
-            governor
+            _governor
         );
 
         address initialAuth = ALBA;

--- a/test/orchestrator/Orchestrator_v1.t.sol
+++ b/test/orchestrator/Orchestrator_v1.t.sol
@@ -32,6 +32,8 @@ import {AuthorizerV1Mock} from "test/utils/mocks/modules/AuthorizerV1Mock.sol";
 import {PaymentProcessorV1Mock} from
     "test/utils/mocks/modules/PaymentProcessorV1Mock.sol";
 import {GovernorV1Mock} from "test/utils/mocks/external/GovernorV1Mock.sol";
+import {ModuleFactoryV1Mock} from
+    "test/utils/mocks/factories/ModuleFactoryV1Mock.sol";
 import {ERC20Mock} from "test/utils/mocks/ERC20Mock.sol";
 
 // Errors
@@ -52,6 +54,7 @@ contract OrchestratorV1Test is Test {
     AuthorizerV1Mock authorizer;
     PaymentProcessorV1Mock paymentProcessor;
     GovernorV1Mock governor;
+    ModuleFactoryV1Mock moduleFactory;
     ERC20Mock token;
     TransactionForwarder_v1 forwarder;
 
@@ -72,6 +75,7 @@ contract OrchestratorV1Test is Test {
         authorizer = new AuthorizerV1Mock();
         paymentProcessor = new PaymentProcessorV1Mock();
         governor = new GovernorV1Mock();
+        moduleFactory = new ModuleFactoryV1Mock();
         forwarder = new TransactionForwarder_v1("TransactionForwarder_v1");
         token = new ERC20Mock("TestToken", "TST");
 
@@ -111,6 +115,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 truncatedModules,
                 fundingManager,
                 authorizer,
@@ -134,6 +139,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 modules,
                 fundingManager,
                 authorizer,
@@ -173,6 +179,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 truncatedModules,
                 fundingManager,
                 authorizer,
@@ -183,6 +190,7 @@ contract OrchestratorV1Test is Test {
             vm.expectRevert(OZErrors.Initializable__InvalidInitialization);
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 truncatedModules,
                 fundingManager,
                 authorizer,
@@ -197,6 +205,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 modules,
                 fundingManager,
                 authorizer,
@@ -207,6 +216,7 @@ contract OrchestratorV1Test is Test {
             vm.expectRevert(OZErrors.Initializable__InvalidInitialization);
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 modules,
                 fundingManager,
                 authorizer,
@@ -236,6 +246,7 @@ contract OrchestratorV1Test is Test {
         // Initialize orchestrator.
         orchestrator.init(
             orchestratorId,
+            address(moduleFactory),
             modules,
             fundingManager,
             authorizer,
@@ -287,6 +298,7 @@ contract OrchestratorV1Test is Test {
         // Initialize orchestrator.
         orchestrator.init(
             orchestratorId,
+            address(moduleFactory),
             modules,
             fundingManager,
             authorizer,
@@ -331,6 +343,7 @@ contract OrchestratorV1Test is Test {
         // Initialize orchestrator.
         orchestrator.init(
             orchestratorId,
+            address(moduleFactory),
             modules,
             fundingManager,
             authorizer,
@@ -377,6 +390,7 @@ contract OrchestratorV1Test is Test {
         // Initialize orchestrator.
         orchestrator.init(
             orchestratorId,
+            address(moduleFactory),
             modules,
             fundingManager,
             authorizer,
@@ -423,6 +437,7 @@ contract OrchestratorV1Test is Test {
         // Initialize orchestrator.
         orchestrator.init(
             orchestratorId,
+            address(moduleFactory),
             modules,
             fundingManager,
             authorizer,
@@ -466,6 +481,7 @@ contract OrchestratorV1Test is Test {
         // Initialize orchestrator.
         orchestrator.init(
             orchestratorId,
+            address(moduleFactory),
             modules,
             fundingManager,
             authorizer,
@@ -511,6 +527,7 @@ contract OrchestratorV1Test is Test {
     ) public {
         orchestrator.init(
             1,
+            address(moduleFactory),
             new address[](0),
             fundingManager,
             authorizer,
@@ -531,6 +548,7 @@ contract OrchestratorV1Test is Test {
     ) public {
         orchestrator.init(
             1,
+            address(moduleFactory),
             new address[](0),
             fundingManager,
             authorizer,
@@ -551,6 +569,7 @@ contract OrchestratorV1Test is Test {
     ) public {
         orchestrator.init(
             1,
+            address(moduleFactory),
             new address[](0),
             fundingManager,
             authorizer,
@@ -590,6 +609,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 truncatedModules,
                 fundingManager,
                 authorizer,
@@ -605,6 +625,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 modules,
                 fundingManager,
                 authorizer,
@@ -639,6 +660,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 truncatedModules,
                 fundingManager,
                 authorizer,
@@ -654,6 +676,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 modules,
                 fundingManager,
                 authorizer,
@@ -690,6 +713,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 truncatedModules,
                 fundingManager,
                 authorizer,
@@ -705,6 +729,7 @@ contract OrchestratorV1Test is Test {
             // Initialize orchestrator.
             orchestrator.init(
                 orchestratorId,
+                address(moduleFactory),
                 modules,
                 fundingManager,
                 authorizer,

--- a/test/orchestrator/abstracts/ModuleManagerBase_v1.t.sol
+++ b/test/orchestrator/abstracts/ModuleManagerBase_v1.t.sol
@@ -140,8 +140,9 @@ contract ModuleManagerBaseV1Test is Test {
         moduleManager.init(address(0), modules);
     }
 
-
-    function testInitFailsForInvalidModuleFactory(address[] memory modules) public {
+    function testInitFailsForInvalidModuleFactory(address[] memory modules)
+        public
+    {
         vm.assume(modules.length > MAX_MODULES);
 
         //we don't need to check for validity since it should revert before

--- a/test/orchestrator/abstracts/ModuleManagerBase_v1.t.sol
+++ b/test/orchestrator/abstracts/ModuleManagerBase_v1.t.sol
@@ -43,7 +43,7 @@ contract ModuleManagerBaseV1Test is Test {
 
     function setUp() public {
         moduleManager = new ModuleManagerBaseV1Mock(address(0));
-        moduleManager.init(EMPTY_LIST);
+        moduleManager.init(address(0), EMPTY_LIST);
 
         types = new TypeSanityHelper(address(moduleManager));
 
@@ -67,9 +67,9 @@ contract ModuleManagerBaseV1Test is Test {
                     .selector
             );
 
-            moduleManager.init(modules);
+            moduleManager.init(address(0), modules);
         } else {
-            moduleManager.init(modules);
+            moduleManager.init(address(0), modules);
 
             // List of modules should be size of modules array.
             address[] memory modulesAdded = moduleManager.listModules();
@@ -84,12 +84,12 @@ contract ModuleManagerBaseV1Test is Test {
 
     function testReinitFails() public {
         vm.expectRevert(OZErrors.Initializable__InvalidInitialization);
-        moduleManager.init(EMPTY_LIST);
+        moduleManager.init(address(0), EMPTY_LIST);
     }
 
     function testInitFailsForNonInitializerFunction() public {
         vm.expectRevert(OZErrors.Initializable__NotInitializing);
-        moduleManager.initNoInitializer(EMPTY_LIST);
+        moduleManager.initNoInitializer(address(0), EMPTY_LIST);
     }
 
     function testInitFailsForInvalidModules() public {
@@ -108,7 +108,7 @@ contract ModuleManagerBaseV1Test is Test {
                     .ModuleManagerBase__InvalidModuleAddress
                     .selector
             );
-            moduleManager.init(modules);
+            moduleManager.init(address(0), modules);
         }
     }
 
@@ -123,7 +123,7 @@ contract ModuleManagerBaseV1Test is Test {
         vm.expectRevert(
             IModuleManagerBase_v1.ModuleManagerBase__IsModule.selector
         );
-        moduleManager.init(modules);
+        moduleManager.init(address(0), modules);
     }
 
     function testInitFailsForTooManyModules(address[] memory modules) public {
@@ -137,7 +137,22 @@ contract ModuleManagerBaseV1Test is Test {
                 .ModuleManagerBase__ModuleAmountOverLimits
                 .selector
         );
-        moduleManager.init(modules);
+        moduleManager.init(address(0), modules);
+    }
+
+
+    function testInitFailsForInvalidModuleFactory(address[] memory modules) public {
+        vm.assume(modules.length > MAX_MODULES);
+
+        //we don't need to check for validity since it should revert before
+
+        moduleManager = new ModuleManagerBaseV1Mock(address(0));
+        vm.expectRevert(
+            IModuleManagerBase_v1
+                .ModuleManagerBase__ModuleFactoryInvalid
+                .selector
+        );
+        moduleManager.unmockedInit(address(0), modules);
     }
 
     //--------------------------------------------------------------------------
@@ -308,6 +323,33 @@ contract ModuleManagerBaseV1Test is Test {
                 .ModuleManagerBase__CallerNotAuthorized
                 .selector
         );
+        moduleManager.call_executeAddModule(who);
+    }
+
+    function testInitiateAddModuleWithTimelock_FailsIfProxyNotRegistered(
+        address who
+    ) public {
+        types.assumeValidModule(who);
+
+        // Test whether the initiation fails
+        moduleManager.__ModuleManager_setRegisteredProxyCheckShouldFail(true);
+
+        vm.expectRevert(
+            IModuleManagerBase_v1
+                .ModuleManagerBase__ModuleNotRegistered
+                .selector
+        );
+        moduleManager.call_initiateAddModuleWithTimelock(who);
+
+        // Afterwards, tests if it works once the proxy is registered properly
+        moduleManager.__ModuleManager_setRegisteredProxyCheckShouldFail(false);
+
+        moduleManager.call_initiateAddModuleWithTimelock(who);
+        vm.warp(block.timestamp + timelock);
+
+        vm.expectEmit(true, true, true, true);
+        emit ModuleAdded(who);
+
         moduleManager.call_executeAddModule(who);
     }
 

--- a/test/utils/mocks/factories/ModuleFactoryV1Mock.sol
+++ b/test/utils/mocks/factories/ModuleFactoryV1Mock.sol
@@ -35,6 +35,19 @@ contract ModuleFactoryV1Mock is IModuleFactory_v1 {
         return (_beacon, LibMetadata.identifier(metadata));
     }
 
+    function getOrchestratorOfProxy(address /*proxy*/ )
+        external
+        view
+        returns (address)
+    {
+        // we return msg.sender here, because this is just a mocked factory.
+        // this means, that when we are using this, we are not actually testing the
+        // real functionality of the factory, but of another contract.
+        // the calling contract (ModuleManager) expects the returned address to be
+        // itself, if the module proxy was created for it properly.
+        return msg.sender;
+    }
+
     function registerMetadata(IModule_v1.Metadata memory, IInverterBeacon_v1)
         external
     {}

--- a/test/utils/mocks/orchestrator/OrchestratorV1AccessMock.sol
+++ b/test/utils/mocks/orchestrator/OrchestratorV1AccessMock.sol
@@ -72,6 +72,7 @@ contract OrchestratorV1AccessMock is IOrchestrator_v1 {
 
     function init(
         uint,
+        address,
         address[] calldata,
         IFundingManager_v1,
         IAuthorizer_v1,

--- a/test/utils/mocks/orchestrator/abstracts/ModuleManagerBaseV1Mock.sol
+++ b/test/utils/mocks/orchestrator/abstracts/ModuleManagerBaseV1Mock.sol
@@ -25,7 +25,9 @@ contract ModuleManagerBaseV1Mock is ModuleManagerBase_v1 {
         _allAuthorized = to;
     }
 
-    function __ModuleManager_setRegisteredProxyCheckShouldFail(bool to) external {
+    function __ModuleManager_setRegisteredProxyCheckShouldFail(bool to)
+        external
+    {
         _registeredProxyCheckShouldFail = to;
     }
 
@@ -51,7 +53,7 @@ contract ModuleManagerBaseV1Mock is ModuleManagerBase_v1 {
         __ModuleManager_init(moduleManager, modules);
     }
 
-    function getOrchestratorOfProxy(address /*proxy*/)
+    function getOrchestratorOfProxy(address /*proxy*/ )
         external
         view
         returns (address)

--- a/test/utils/mocks/orchestrator/abstracts/ModuleManagerBaseV1Mock.sol
+++ b/test/utils/mocks/orchestrator/abstracts/ModuleManagerBaseV1Mock.sol
@@ -11,6 +11,7 @@ contract ModuleManagerBaseV1Mock is ModuleManagerBase_v1 {
     mapping(address => bool) private _authorized;
 
     bool private _allAuthorized;
+    bool private _registeredProxyCheckShouldFail;
 
     constructor(address _trustedForwarder)
         ModuleManagerBase_v1(_trustedForwarder)
@@ -24,13 +25,38 @@ contract ModuleManagerBaseV1Mock is ModuleManagerBase_v1 {
         _allAuthorized = to;
     }
 
-    function init(address[] calldata modules) external initializer {
-        __ModuleManager_init(modules);
+    function __ModuleManager_setRegisteredProxyCheckShouldFail(bool to) external {
+        _registeredProxyCheckShouldFail = to;
+    }
+
+    function init(address, /*moduleManager*/ address[] calldata modules)
+        external
+        initializer
+    {
+        __ModuleManager_init(address(this), modules);
     }
 
     // Note that the `initializer` modifier is missing.
-    function initNoInitializer(address[] calldata modules) external {
-        __ModuleManager_init(modules);
+    function initNoInitializer(
+        address, /*moduleManager*/
+        address[] calldata modules
+    ) external {
+        __ModuleManager_init(address(this), modules);
+    }
+
+    function unmockedInit(address moduleManager, address[] calldata modules)
+        external
+        initializer
+    {
+        __ModuleManager_init(moduleManager, modules);
+    }
+
+    function getOrchestratorOfProxy(address /*proxy*/)
+        external
+        view
+        returns (address)
+    {
+        return _registeredProxyCheckShouldFail ? address(0) : address(this);
     }
 
     function call_cancelModuleUpdate(address module) external {


### PR DESCRIPTION
This PR limits the ModuleManager to only allow adding modules that have previously been created via our own factory. Basically, whenever a module is created in the `ModuleFactory` via `createModule` (which deploys the proxy), we store this `proxy` in a mapping that returns the address of the Orchestrator, for which it has been created. This way, the Module Manager (which is the Orchestrator by inheritance), can just verify whether the returned address is `address(this)`(aka itself) to ensure that this module is (a) registered and (b) has been created for itself, not for a different Orchestrator.

I adapted the tests and everything should (tm) be okay. 🤞 