### PR TITLE
[SC-382] Audit(L-8): Removal of token gated role does not remove role associated data

### DIFF
--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -110,7 +110,7 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     /// @param role The role to grant
     /// @param who The address to grant the role to
     /// @return bool Returns if the role has been granted succesful
-    /// @dev Overrides {_grantRole} from AccesControl to enforce interface implementation when role is token-gated
+    /// @dev Overrides {_grantRole} from AccesControl to enforce interface implementation and threshold existence when role is token-gated
     function _grantRole(bytes32 role, address who)
         internal
         virtual
@@ -133,10 +133,11 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
         return super._grantRole(role, who);
     }
 
-    /// @notice Overrides {_revokeRole} to prevent having an empty OWNER role
+
     /// @param role The id number of the role
     /// @param who The user we want to check on
     /// @return bool Returns if revoke has been succesful
+    /// @dev Overrides {_revokeRole} to clean up threshold data on revoking
     function _revokeRole(bytes32 role, address who)
         internal
         virtual

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -92,7 +92,7 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     //--------------------------------------------------------------------------
     // Overloaded and overriden functions
 
-    function hasRole(bytes32 roleId, address account)
+    function hasRole(bytes32 roleId, address who)
         public
         view
         virtual
@@ -100,31 +100,54 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
         returns (bool)
     {
         if (isTokenGated[roleId]) {
-            return _hasTokenRole(roleId, account);
+            return _hasTokenRole(roleId, who);
         } else {
-            return super.hasRole(roleId, account);
+            return super.hasRole(roleId, who);
         }
     }
 
     /// @notice Grants a role to an address
     /// @param role The role to grant
-    /// @param account The address to grant the role to
+    /// @param who The address to grant the role to
     /// @return bool Returns if the role has been granted succesful
     /// @dev Overrides {_grantRole} from AccesControl to enforce interface implementation when role is token-gated
-    function _grantRole(bytes32 role, address account)
+    function _grantRole(bytes32 role, address who)
         internal
         virtual
         override
         returns (bool)
     {
         if (isTokenGated[role]) {
-            try TokenInterface(account).balanceOf(address(this)) {}
+            // Make sure that a threshold has been set before granting the role
+            if (getThresholdValue(role, who) == 0) {
+                revert Module__AUT_TokenGated_Roles__TokenRoleMustHaveThreshold(
+                    role, who
+                );
+            }
+            try TokenInterface(who).balanceOf(address(this)) {}
             catch {
-                revert Module__AUT_TokenGated_Roles__InvalidToken(account);
+                revert Module__AUT_TokenGated_Roles__InvalidToken(who);
             }
         }
 
-        return super._grantRole(role, account);
+        return super._grantRole(role, who);
+    }
+
+    /// @notice Overrides {_revokeRole} to prevent having an empty OWNER role
+    /// @param role The id number of the role
+    /// @param who The user we want to check on
+    /// @return bool Returns if revoke has been succesful
+    function _revokeRole(bytes32 role, address who)
+        internal
+        virtual
+        override
+        returns (bool)
+    {
+        if (isTokenGated[role]) {
+            // set the threshold to 0 before revoking the role from the token
+            _setThreshold(role, who, 0);
+        }
+        return super._revokeRole(role, who);
     }
 
     //--------------------------------------------------------------------------
@@ -172,8 +195,8 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
         uint threshold
     ) external onlyModule(_msgSender()) {
         bytes32 roleId = generateRoleId(_msgSender(), role);
-        _grantRole(roleId, token);
         _setThreshold(roleId, token, threshold);
+        _grantRole(roleId, token);
     }
 
     /// @inheritdoc IAUT_TokenGated_Roles_v1

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -110,7 +110,7 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     /// @param role The role to grant
     /// @param who The address to grant the role to
     /// @return bool Returns if the role has been granted succesful
-    /// @dev Overrides {_grantRole} from AccesControl to enforce interface implementation and threshold existence when role is token-gated
+    /// @dev Overrides {_grantRole} from AccessControl to enforce interface implementation and threshold existence when role is token-gated
     function _grantRole(bytes32 role, address who)
         internal
         virtual
@@ -133,7 +133,6 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
         return super._grantRole(role, who);
     }
 
-
     /// @param role The id number of the role
     /// @param who The user we want to check on
     /// @return bool Returns if revoke has been succesful
@@ -146,7 +145,9 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     {
         if (isTokenGated[role]) {
             // Set the threshold to 0 before revoking the role from the token
-            _setThreshold(role, who, 0);
+            bytes32 thresholdId = keccak256(abi.encodePacked(role, who));
+            thresholdMap[thresholdId] = 0;
+            emit ChangedTokenThreshold(role, who, 0);
         }
         return super._revokeRole(role, who);
     }

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -144,7 +144,7 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
         returns (bool)
     {
         if (isTokenGated[role]) {
-            // set the threshold to 0 before revoking the role from the token
+            // Set the threshold to 0 before revoking the role from the token
             _setThreshold(role, who, 0);
         }
         return super._revokeRole(role, who);

--- a/src/modules/authorizer/role/interfaces/IAUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/interfaces/IAUT_TokenGated_Roles_v1.sol
@@ -33,6 +33,11 @@ interface IAUT_TokenGated_Roles_v1 is IAuthorizer_v1 {
     /// @notice The given threshold is invalid
     error Module__AUT_TokenGated_Roles__InvalidThreshold(uint threshold);
 
+    /// @notice The role is token-gated but no threshold is set.
+    error Module__AUT_TokenGated_Roles__TokenRoleMustHaveThreshold(
+        bytes32 role, address token
+    );
+
     //--------------------------------------------------------------------------
     // Public functions
 

--- a/test/e2e/authorizer/TokenGatedRoleAuthorizerE2E.t.sol
+++ b/test/e2e/authorizer/TokenGatedRoleAuthorizerE2E.t.sol
@@ -129,8 +129,8 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
                 address(bountyManager), bountyManager.BOUNTY_ISSUER_ROLE()
             );
             authorizer.setTokenGated(bountyRoleId, true);
-            authorizer.grantRole(bountyRoleId, address(gatingToken));
             authorizer.setThreshold(bountyRoleId, address(gatingToken), 100);
+            authorizer.grantRole(bountyRoleId, address(gatingToken));
 
             // We mint 101 tokens to the orchestrator owner so they can create bounties
             gatingToken.mint(orchestratorOwner, 101);
@@ -140,8 +140,8 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
                 address(bountyManager), bountyManager.VERIFIER_ROLE()
             );
             authorizer.setTokenGated(verifierRoleId, true);
-            authorizer.grantRole(verifierRoleId, address(gatingToken));
             authorizer.setThreshold(verifierRoleId, address(gatingToken), 50);
+            authorizer.grantRole(verifierRoleId, address(gatingToken));
 
             // We mint 51 tokens to the orchestrator manager so they can verify bounties
             gatingToken.mint(orchestratorManager, 51);
@@ -151,8 +151,8 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
                 address(bountyManager), bountyManager.CLAIMANT_ROLE()
             );
             authorizer.setTokenGated(claimRoleId, true);
-            authorizer.grantRole(claimRoleId, address(gatingToken));
             authorizer.setThreshold(claimRoleId, address(gatingToken), 25);
+            authorizer.grantRole(claimRoleId, address(gatingToken));
 
             // We mint 26 tokens to the bounty submitter so they can submit bounties
             gatingToken.mint(bountySubmitter, 26);

--- a/test/modules/authorizer/role/AUT_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_Roles_v1.t.sol
@@ -401,7 +401,7 @@ contract AUT_RolesV1Test is Test {
 
         vm.startPrank(address(BOB));
         for (uint i; i < newAuthorized.length; ++i) {
-            vm.expectRevert(); // Just a general revert since AccesControl doesn't have error types
+            vm.expectRevert(); // Just a general revert since AccessControl doesn't have error types
             _authorizer.grantRole(managerRole, newAuthorized[i]);
         }
         vm.stopPrank();
@@ -473,7 +473,7 @@ contract AUT_RolesV1Test is Test {
 
         vm.startPrank(address(BOB));
         for (uint i; i < newAuthorized.length; ++i) {
-            vm.expectRevert(); // Just a general revert since AccesControl doesn't have error types
+            vm.expectRevert(); // Just a general revert since AccessControl doesn't have error types
             _authorizer.revokeRole(managerRole, newAuthorized[i]);
         }
         vm.stopPrank();

--- a/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
@@ -152,6 +152,7 @@ contract TokenGatedAUT_RoleV1Test is Test {
             _METADATA,
             abi.encode(initialAuth, initialManager)
         );
+
         assertEq(
             _authorizer.hasRole(_authorizer.getManagerRole(), address(this)),
             true
@@ -523,6 +524,75 @@ contract TokenGatedAUT_RoleV1Test is Test {
             )
         );
         _authorizer.setThresholdFromModule(ROLE_TOKEN, address(roleToken), 500);
+    }
+
+    // Threshold state checks:
+    // Cannot grant role if threshold is set to zero
+
+    function testGrantTokenRoleFailsIfThresholdWouldBeZero() public {
+        bytes32 role = ROLE_TOKEN;
+
+        //Make the role token-gated, but don't set a token with grantRoleFromModule()
+        vm.prank(address(mockModule));
+        _authorizer.makeRoleTokenGatedFromModule(role);
+
+        bytes32 storedRoleId =
+            _authorizer.generateRoleId(address(mockModule), role);
+
+        // Now we make BOB admin of the role
+        makeAddressDefaultAdmin(BOB);
+
+        vm.startPrank(BOB);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAUT_TokenGated_Roles_v1
+                    .Module__AUT_TokenGated_Roles__TokenRoleMustHaveThreshold
+                    .selector,
+                storedRoleId,
+                address(roleToken)
+            )
+        );
+        _authorizer.grantRole(storedRoleId, address(roleToken)); // BOB tries to circumvent setting a threshold
+
+        vm.stopPrank();
+    }
+
+
+    // Threshold is zero after revoking role
+
+    function testThresholdStateGetsDeletedOnRevoke() public {
+        bytes32 role = ROLE_TOKEN;
+        bytes32 moduleRoleId =
+            _authorizer.generateRoleId(address(mockModule), role);
+
+        assertEq(
+            _authorizer.getThresholdValue(moduleRoleId, address(roleToken)), 0
+        );
+
+        vm.startPrank(address(mockModule));
+
+        //Make the role token-gated with a threshold of 500
+        _authorizer.makeRoleTokenGatedFromModule(role);
+        _authorizer.grantTokenRoleFromModule(role, address(roleToken), 500);
+
+        assertEq(
+            _authorizer.getThresholdValue(moduleRoleId, address(roleToken)), 500
+        );
+
+        _authorizer.revokeRoleFromModule(role, address(roleToken));
+
+        assertEq(
+            _authorizer.getThresholdValue(moduleRoleId, address(roleToken)), 0
+        );
+
+        // Grant the same role again, with different Threshold
+        _authorizer.grantTokenRoleFromModule(role, address(roleToken), 250);
+
+        assertEq(
+            _authorizer.getThresholdValue(moduleRoleId, address(roleToken)), 250
+        );
+
+        vm.stopPrank();
     }
 
     //Test Authorization

--- a/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
@@ -557,7 +557,6 @@ contract TokenGatedAUT_RoleV1Test is Test {
         vm.stopPrank();
     }
 
-
     // Threshold is zero after revoking role
 
     function testThresholdStateGetsDeletedOnRevoke() public {


### PR DESCRIPTION
## What has been done
- Add state deletion on token role removal.

While fixing the issue I realized that there was another edge case possible: adding a token role through the grantModuleRole of the parent contract once it was set as tokenGated would set the threshold at the default value (-> 0), effectively circumventing authorization.
- Added extra check on role granting to address that