### PR TITLE
[SC-373] Bug(L-5): Missing validation for liveness in OptimisticOracleIntegrator

### DIFF
--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -136,7 +136,8 @@ abstract contract OptimisticOracleIntegrator is
     }
 
     function _setDefaultAssertionLiveness(uint64 _newLiveness) internal {
-        if (_newLiveness == 0) {
+        if (_newLiveness < 21_600) {
+            // 21600 seconds = 6 hours
             revert Module__OptimisticOracleIntegrator__InvalidDefaultLiveness();
         }
         assertionLiveness = _newLiveness;

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -99,7 +99,7 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
     address AUTOMATION_SERVICE = address(0x6E1A70); // The automation service that will post the assertion and do the callback
 
     // Assertion mock data
-    uint64 constant ASSERTION_LIVENESS = 5000;
+    uint64 constant ASSERTION_LIVENESS = 25_000;
     bytes32 constant MOCK_ASSERTION_DATA_ID = "0x1234";
     bytes32 constant MOCK_ASSERTION_DATA = "This is test data";
     address constant MOCK_ASSERTER_ADDRESS = address(0x1);

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -42,7 +42,7 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
 
     OptimisticOracleV3Mock ooV3;
 
-    uint64 immutable DEFAULT_LIVENESS = 5000;
+    uint64 immutable DEFAULT_LIVENESS = 25_000;
 
     // Mock data for assertions
     bytes32 constant MOCK_ASSERTION_DATA_ID = "0x1234";

--- a/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
+++ b/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
@@ -34,7 +34,7 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
     OptimisticOracleIntegratorMock ooIntegrator;
     OptimisticOracleV3Mock ooV3;
 
-    uint64 immutable DEFAULT_LIVENESS = 5000;
+    uint64 immutable DEFAULT_LIVENESS = 25_000;
 
     // Mock data for assertions
     bytes32 constant MOCK_ASSERTION_DATA_ID = "0x1234";
@@ -222,24 +222,27 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
         When the caller is not the owner
             reverts (tested in module tests)
         When the caller is the owner
-            when the liveness is 0
+            when the liveness is below 6 hours
                 reverts
             when the liveness is valid 
                 sets the new liveness
                 emits an event
     */
 
-    function testSetDefaultAssertionLivenessFails_whenLivenessIsZero() public {
+    function testSetDefaultAssertionLivenessFails_whenLivenessLessThanSixHours(
+        uint64 newLiveness
+    ) public {
+        vm.assume(newLiveness < 21_600);
         vm.expectRevert(
             IOptimisticOracleIntegrator
                 .Module__OptimisticOracleIntegrator__InvalidDefaultLiveness
                 .selector
         );
-        ooIntegrator.setDefaultAssertionLiveness(0);
+        ooIntegrator.setDefaultAssertionLiveness(newLiveness);
     }
 
     function testSetDefaultAssertionLiveness(uint64 newLiveness) public {
-        vm.assume(newLiveness > 0);
+        vm.assume(newLiveness >= 21_600);
         ooIntegrator.setDefaultAssertionLiveness(newLiveness);
         assertEq(ooIntegrator.assertionLiveness(), newLiveness);
     }


### PR DESCRIPTION
## What has been done

- Increased minimum assertion liveness to 21_600 (6 hours) and adapted tests