### PR TITLE
[SC-485] Audit (H-6) Modules assume the fundingmanagers token can not change

### DIFF
--- a/src/orchestrator/Orchestrator_v1.sol
+++ b/src/orchestrator/Orchestrator_v1.sol
@@ -278,8 +278,15 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
                     fundingManagerContract, fundingManagerInterfaceId
                 )
         ) {
-            _initiateAddModuleWithTimelock(fundingManagerContract);
-            _initiateRemoveModuleWithTimelock(address(fundingManager));
+            if (fundingManager.token() != fundingManager_.token()) {
+                revert Orchestrator__MismatchedTokenForFundingManager(
+                    address(fundingManager.token()),
+                    address(fundingManager_.token())
+                );
+            } else {
+                _initiateAddModuleWithTimelock(fundingManagerContract);
+                _initiateRemoveModuleWithTimelock(address(fundingManager));
+            }
         } else {
             revert Orchestrator__InvalidModuleType(fundingManagerContract);
         }

--- a/src/orchestrator/interfaces/IOrchestrator_v1.sol
+++ b/src/orchestrator/interfaces/IOrchestrator_v1.sol
@@ -26,6 +26,11 @@ interface IOrchestrator_v1 is IModuleManagerBase_v1 {
     /// @notice The given module is not used in the orchestrator
     error Orchestrator__InvalidModuleType(address module);
 
+    /// @notice The token of the new funding manager is not the same as the current funding manager.
+    error Orchestrator__MismatchedTokenForFundingManager(
+        address currentToken, address newToken
+    );
+
     /// @notice The given module is not used in the orchestrator
     error Orchestrator__DependencyInjection__ModuleNotUsedInOrchestrator();
 


### PR DESCRIPTION
## What has been done
- Added a check when initiating a FundingManager change that ensures both FM's use the same token
- Added unit tests