### PR TITLE
[Sc-494] Audit (M-8) orchestrator should not be its own owner

### DIFF
--- a/src/modules/authorizer/IAuthorizer_v1.sol
+++ b/src/modules/authorizer/IAuthorizer_v1.sol
@@ -17,6 +17,9 @@ interface IAuthorizer_v1 is IAccessControlEnumerable {
     /// @notice There always needs to be at least one owner.
     error Module__Authorizer__OwnerRoleCannotBeEmpty();
 
+    /// @notice The orchestrator cannot own itself
+    error Module__Authorizer__OrchestratorCannotHaveOwnerRole();
+
     //--------------------------------------------------------------------------
     // Functions
 

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -80,6 +80,14 @@ contract AUT_Roles_v1 is
         _;
     }
 
+    /// @notice Verifies that the owner being added is not the orchestrator
+    modifier noSelfOwner(bytes32 role, address who) {
+        if (role == ORCHESTRATOR_OWNER_ROLE && who == address(orchestrator())) {
+            revert Module__Authorizer__OrchestratorCannotHaveOwnerRole();
+        }
+        _;
+    }
+
     //--------------------------------------------------------------------------
     // Constructor and initialization
 
@@ -147,6 +155,20 @@ contract AUT_Roles_v1 is
         returns (bool)
     {
         return super._revokeRole(role, who);
+    }
+
+    /// @notice Overrides {_grantRole} to prevent having the Orchestrator having the OWNER role
+    /// @param role The id number of the role
+    /// @param who The user we want to check on
+    /// @return bool Returns if grant has been succesful
+    function _grantRole(bytes32 role, address who)
+        internal
+        virtual
+        override
+        noSelfOwner(role, who)
+        returns (bool)
+    {
+        return super._grantRole(role, who);
     }
 
     //--------------------------------------------------------------------------

--- a/test/modules/authorizer/role/AUT_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_Roles_v1.t.sol
@@ -308,6 +308,24 @@ contract AUT_RolesV1Test is Test {
         );
     }
 
+    function testGrantOwnerRoleFailsIfOrchestratorWillBeOwner() public {
+        vm.startPrank(address(ALBA));
+
+        bytes32 ownerRole = _authorizer.getOwnerRole();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAuthorizer_v1
+                    .Module__Authorizer__OrchestratorCannotHaveOwnerRole
+                    .selector
+            )
+        );
+
+        _authorizer.grantRole(ownerRole, address(_orchestrator));
+
+        vm.stopPrank();
+    }
+
     function testRevokeOwnerRole() public {
         //Add Bob as owner
         vm.startPrank(address(ALBA));


### PR DESCRIPTION
## What has been done
- Added a modifier to the _grantRole function to ensure an orchestrator can't own itself