### PR TITLE
[SC-506] Audit(H-7): Asserted data unrelated to the assertedValue used in rewards

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -156,9 +156,6 @@ contract LM_PC_KPIRewarder_v1 is
             revert Module__LM_PC_KPIRewarder_v1__InvalidKPINumber();
         }
 
-        // Question: what kind of checks should or can we implement on the data side?
-        // Technically the value mentioned inside "data" (and posted publicly) wouldn't need to be the same as assertedValue...
-
         // =====================================================================
         // Staking Queue Management
 

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -135,9 +135,8 @@ contract LM_PC_KPIRewarder_v1 is
     /// If the asserter is set to 0, whomever calls postAssertion will be paying the bond.
     function postAssertion(
         bytes32 dataId,
-        bytes32 data,
-        address asserter,
         uint assertedValue,
+        address asserter,
         uint targetKPI
     ) public onlyModuleRole(ASSERTER_ROLE) returns (bytes32 assertionId) {
         // =====================================================================
@@ -175,7 +174,7 @@ contract LM_PC_KPIRewarder_v1 is
         // =====================================================================
         // Assertion Posting
 
-        assertionId = assertDataFor(dataId, data, asserter);
+        assertionId = assertDataFor(dataId, bytes32(assertedValue), asserter);
         assertionConfig[assertionId] = RewardRoundConfiguration(
             block.timestamp, assertedValue, targetKPI, false
         );

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -82,16 +82,14 @@ interface ILM_PC_KPIRewarder_v1 {
 
     /// @notice Posts an assertion to the Optimistic Oracle, specifying the KPI to use and the asserted value
     /// @param dataId The dataId to be posted
-    /// @param data The data to be posted
+    /// @param assertedValue The target value that will be asserted and posted as data to the oracle
     /// @param asserter The address of the asserter
-    /// @param assertedValue The target value that will be asserted
     /// @param targetKPI The KPI to be used for distribution once the assertion confirms
     /// @return assertionId The assertionId received for the posted assertion
     function postAssertion(
         bytes32 dataId,
-        bytes32 data,
-        address asserter,
         uint assertedValue,
+        address asserter,
         uint targetKPI
     ) external returns (bytes32 assertionId);
 

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -102,9 +102,8 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
     // Assertion mock data
     uint64 constant ASSERTION_LIVENESS = 25_000;
     bytes32 constant MOCK_ASSERTION_DATA_ID = "0x1234";
-    bytes32 constant MOCK_ASSERTION_DATA = "This is test data";
-    address constant MOCK_ASSERTER_ADDRESS = address(0x1);
     uint constant MOCK_ASSERTED_VALUE = 250;
+    address constant MOCK_ASSERTER_ADDRESS = address(0x1);
 
     // KPI mock data
     uint constant NUM_OF_TRANCHES = 4;

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -337,9 +337,8 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
         vm.prank(AUTOMATION_SERVICE);
         bytes32 assertionId = kpiRewarder.postAssertion(
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
             MOCK_ASSERTED_VALUE,
+            MOCK_ASSERTER_ADDRESS,
             0 // target KPI
         );
 

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -355,16 +355,15 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
+            bytes32(MOCK_ASSERTED_VALUE),
             MOCK_ASSERTER_ADDRESS,
             0x0
         );
         vm.prank(address(MOCK_ASSERTER_ADDRESS));
         bytes32 assertionId = kpiManager.postAssertion(
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
+            MOCK_ASSERTED_VALUE,
             MOCK_ASSERTER_ADDRESS,
-            100,
             0
         );
 
@@ -380,9 +379,8 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         vm.prank(address(MOCK_ASSERTER_ADDRESS));
         assertionId = kpiManager.postAssertion(
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
+            MOCK_ASSERTED_VALUE,
             MOCK_ASSERTER_ADDRESS,
-            100,
             0
         );
 

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -48,7 +48,7 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
 
     // Mock data for assertions
     bytes32 constant MOCK_ASSERTION_DATA_ID = "0x1234";
-    bytes32 constant MOCK_ASSERTION_DATA = "This is test data";
+    uint256 constant MOCK_ASSERTION_DATA = 100;
     address constant MOCK_ASSERTER_ADDRESS = address(0x1);
     address USER_1 = address(0xA1BA);
 
@@ -301,11 +301,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
                 .selector
         );
         alt_kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            address(alt_kpiManager),
-            100,
-            0
+            MOCK_ASSERTION_DATA_ID, 100, address(alt_kpiManager), 0
         );
     }
 
@@ -317,11 +313,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
                 .selector
         );
         kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            100,
-            99_999
+            MOCK_ASSERTION_DATA_ID, 100, MOCK_ASSERTER_ADDRESS, 99_999
         );
     }
 
@@ -335,11 +327,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
                 .selector
         );
         kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            100,
-            99_999
+            MOCK_ASSERTION_DATA_ID, 100, MOCK_ASSERTER_ADDRESS, 99_999
         );
     }
 
@@ -376,18 +364,11 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         }
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            0x0
+            MOCK_ASSERTION_DATA_ID, bytes32(MOCK_ASSERTION_DATA), MOCK_ASSERTER_ADDRESS, 0x0
         ); //we don't know the last one
 
         bytes32 assertionId = kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            100,
-            0
+            MOCK_ASSERTION_DATA_ID, 100, MOCK_ASSERTER_ADDRESS, 0
         );
         vm.stopPrank();
 
@@ -408,7 +389,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
             kpiManager.getAssertionConfig(assertionId);
 
         assertEq(assertion.dataId, MOCK_ASSERTION_DATA_ID);
-        assertEq(assertion.data, MOCK_ASSERTION_DATA);
+        assertEq(assertion.data, bytes32(MOCK_ASSERTION_DATA));
         assertEq(assertion.asserter, MOCK_ASSERTER_ADDRESS);
 
         assertEq(rewardRoundConfig.creationTime, block.timestamp);
@@ -438,18 +419,11 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         // SuT
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            0x0
+            MOCK_ASSERTION_DATA_ID, bytes32(MOCK_ASSERTION_DATA), MOCK_ASSERTER_ADDRESS, 0x0
         );
         vm.prank(address(MOCK_ASSERTER_ADDRESS));
         bytes32 assertionId = kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            100,
-            0
+            MOCK_ASSERTION_DATA_ID, 100, MOCK_ASSERTER_ADDRESS, 0
         );
 
         // state after
@@ -465,7 +439,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
             kpiManager.getAssertionConfig(assertionId);
 
         assertEq(assertion.dataId, MOCK_ASSERTION_DATA_ID);
-        assertEq(assertion.data, MOCK_ASSERTION_DATA);
+        assertEq(assertion.data, bytes32(MOCK_ASSERTION_DATA));
         assertEq(assertion.asserter, MOCK_ASSERTER_ADDRESS);
 
         assertEq(rewardRoundConfig.creationTime, block.timestamp);
@@ -504,11 +478,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         vm.prank(address(MOCK_ASSERTER_ADDRESS));
         vm.expectRevert(); // ERC20 insufficient balance revert
         bytes32 assertionId = kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            100,
-            0
+            MOCK_ASSERTION_DATA_ID, 100, MOCK_ASSERTER_ADDRESS, 0
         );
 
         // state after
@@ -839,17 +809,13 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
+            bytes32(valueToAssert),
             MOCK_ASSERTER_ADDRESS,
             0x0
         ); //we don't know the last one
 
         assertionId = kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
-            MOCK_ASSERTER_ADDRESS,
-            valueToAssert,
-            0
+            MOCK_ASSERTION_DATA_ID, valueToAssert, MOCK_ASSERTER_ADDRESS, 0
         );
         vm.stopPrank();
 
@@ -860,11 +826,15 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         address[] memory users,
         uint[] memory amounts
     ) external {
+
+        uint256 assertedIntermediateValue = 250;
+
+
         // it should emit an event
         bytes32 createdID;
         uint totalStakedFunds;
         (createdID, users, amounts, totalStakedFunds) =
-            setUpStateForAssertionResolution(users, amounts, 250, true);
+            setUpStateForAssertionResolution(users, amounts, assertedIntermediateValue, true);
 
         vm.startPrank(address(ooV3));
         vm.expectEmit(true, true, true, true, address(kpiManager));
@@ -873,7 +843,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         emit DataAssertionResolved(
             false,
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
+            bytes32(assertedIntermediateValue),
             MOCK_ASSERTER_ADDRESS,
             createdID
         );
@@ -898,10 +868,12 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
 
         vm.assume(users.length > 1);
 
+        uint256 assertedIntermediateValue = 250;
+
         bytes32 createdID;
         uint totalStakedFunds;
         (createdID, users, amounts, totalStakedFunds) =
-            setUpStateForAssertionResolution(users, amounts, 250, true);
+            setUpStateForAssertionResolution(users, amounts, assertedIntermediateValue, true);
 
         vm.startPrank(address(ooV3));
 
@@ -912,7 +884,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         emit DataAssertionResolved(
             true,
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
+            bytes32(assertedIntermediateValue),
             MOCK_ASSERTER_ADDRESS,
             createdID
         );
@@ -972,10 +944,12 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
     ) external whenTheAssertionResolvedToTrue {
         // it should not pay out any amount from the uncompleted tranche at all
 
+        uint256 assertedIntermediateValue = 250;
+
         bytes32 createdID;
         uint totalStakedFunds;
         (createdID, users, amounts, totalStakedFunds) =
-            setUpStateForAssertionResolution(users, amounts, 250, false);
+            setUpStateForAssertionResolution(users, amounts, assertedIntermediateValue, false);
 
         vm.warp(block.timestamp + 5);
 
@@ -988,7 +962,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         emit DataAssertionResolved(
             true,
             MOCK_ASSERTION_DATA_ID,
-            MOCK_ASSERTION_DATA,
+            bytes32(assertedIntermediateValue),
             MOCK_ASSERTER_ADDRESS,
             createdID
         );

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -48,7 +48,7 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
 
     // Mock data for assertions
     bytes32 constant MOCK_ASSERTION_DATA_ID = "0x1234";
-    uint constant MOCK_ASSERTION_DATA = 100;
+    uint constant MOCK_ASSERTED_VALUE = 100;
     address constant MOCK_ASSERTER_ADDRESS = address(0x1);
     address USER_1 = address(0xA1BA);
 
@@ -365,7 +365,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
             MOCK_ASSERTION_DATA_ID,
-            bytes32(MOCK_ASSERTION_DATA),
+            bytes32(MOCK_ASSERTED_VALUE),
             MOCK_ASSERTER_ADDRESS,
             0x0
         ); //we don't know the last one
@@ -392,7 +392,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
             kpiManager.getAssertionConfig(assertionId);
 
         assertEq(assertion.dataId, MOCK_ASSERTION_DATA_ID);
-        assertEq(assertion.data, bytes32(MOCK_ASSERTION_DATA));
+        assertEq(assertion.data, bytes32(MOCK_ASSERTED_VALUE));
         assertEq(assertion.asserter, MOCK_ASSERTER_ADDRESS);
 
         assertEq(rewardRoundConfig.creationTime, block.timestamp);
@@ -423,7 +423,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
             MOCK_ASSERTION_DATA_ID,
-            bytes32(MOCK_ASSERTION_DATA),
+            bytes32(MOCK_ASSERTED_VALUE),
             MOCK_ASSERTER_ADDRESS,
             0x0
         );
@@ -445,7 +445,7 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
             kpiManager.getAssertionConfig(assertionId);
 
         assertEq(assertion.dataId, MOCK_ASSERTION_DATA_ID);
-        assertEq(assertion.data, bytes32(MOCK_ASSERTION_DATA));
+        assertEq(assertion.data, bytes32(MOCK_ASSERTED_VALUE));
         assertEq(assertion.asserter, MOCK_ASSERTER_ADDRESS);
 
         assertEq(rewardRoundConfig.creationTime, block.timestamp);

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -48,7 +48,7 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
 
     // Mock data for assertions
     bytes32 constant MOCK_ASSERTION_DATA_ID = "0x1234";
-    uint256 constant MOCK_ASSERTION_DATA = 100;
+    uint constant MOCK_ASSERTION_DATA = 100;
     address constant MOCK_ASSERTER_ADDRESS = address(0x1);
     address USER_1 = address(0xA1BA);
 
@@ -364,7 +364,10 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         }
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
-            MOCK_ASSERTION_DATA_ID, bytes32(MOCK_ASSERTION_DATA), MOCK_ASSERTER_ADDRESS, 0x0
+            MOCK_ASSERTION_DATA_ID,
+            bytes32(MOCK_ASSERTION_DATA),
+            MOCK_ASSERTER_ADDRESS,
+            0x0
         ); //we don't know the last one
 
         bytes32 assertionId = kpiManager.postAssertion(
@@ -419,7 +422,10 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
         // SuT
         vm.expectEmit(true, false, false, false, address(kpiManager));
         emit DataAsserted(
-            MOCK_ASSERTION_DATA_ID, bytes32(MOCK_ASSERTION_DATA), MOCK_ASSERTER_ADDRESS, 0x0
+            MOCK_ASSERTION_DATA_ID,
+            bytes32(MOCK_ASSERTION_DATA),
+            MOCK_ASSERTER_ADDRESS,
+            0x0
         );
         vm.prank(address(MOCK_ASSERTER_ADDRESS));
         bytes32 assertionId = kpiManager.postAssertion(
@@ -826,15 +832,15 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         address[] memory users,
         uint[] memory amounts
     ) external {
-
-        uint256 assertedIntermediateValue = 250;
-
+        uint assertedIntermediateValue = 250;
 
         // it should emit an event
         bytes32 createdID;
         uint totalStakedFunds;
         (createdID, users, amounts, totalStakedFunds) =
-            setUpStateForAssertionResolution(users, amounts, assertedIntermediateValue, true);
+        setUpStateForAssertionResolution(
+            users, amounts, assertedIntermediateValue, true
+        );
 
         vm.startPrank(address(ooV3));
         vm.expectEmit(true, true, true, true, address(kpiManager));
@@ -868,12 +874,14 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
 
         vm.assume(users.length > 1);
 
-        uint256 assertedIntermediateValue = 250;
+        uint assertedIntermediateValue = 250;
 
         bytes32 createdID;
         uint totalStakedFunds;
         (createdID, users, amounts, totalStakedFunds) =
-            setUpStateForAssertionResolution(users, amounts, assertedIntermediateValue, true);
+        setUpStateForAssertionResolution(
+            users, amounts, assertedIntermediateValue, true
+        );
 
         vm.startPrank(address(ooV3));
 
@@ -944,12 +952,14 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
     ) external whenTheAssertionResolvedToTrue {
         // it should not pay out any amount from the uncompleted tranche at all
 
-        uint256 assertedIntermediateValue = 250;
+        uint assertedIntermediateValue = 250;
 
         bytes32 createdID;
         uint totalStakedFunds;
         (createdID, users, amounts, totalStakedFunds) =
-            setUpStateForAssertionResolution(users, amounts, assertedIntermediateValue, false);
+        setUpStateForAssertionResolution(
+            users, amounts, assertedIntermediateValue, false
+        );
 
         vm.warp(block.timestamp + 5);
 


### PR DESCRIPTION
## What has been done
When calling postAssertion, the KPIRewarder now sends the assertedValue as data.