### PR TITLE
[SC-397] Audit(Q-4): Unused errors

### DIFF
--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -46,9 +46,6 @@ interface ILM_PC_KPIRewarder_v1 {
     /// @notice The KPI number is invalid
     error Module__LM_PC_KPIRewarder_v1__InvalidKPINumber();
 
-    /// @notice The target value for the assertion cannot be zero
-    error Module__LM_PC_KPIRewarder_v1__InvalidTargetValue();
-
     /// @notice The Queue for new stakers is full
     error Module__LM_PC_KPIRewarder_v1__StakingQueueIsFull();
 

--- a/src/orchestrator/interfaces/IModuleManagerBase_v1.sol
+++ b/src/orchestrator/interfaces/IModuleManagerBase_v1.sol
@@ -34,9 +34,6 @@ interface IModuleManagerBase_v1 is IERC2771Context {
     /// @notice Given address is not a module.
     error ModuleManagerBase__IsNotModule();
 
-    /// @notice The supplied modules are not consecutive.
-    error ModuleManagerBase__ModulesNotConsecutive();
-
     /// @notice The Manager has reached the maximum amount of modules.
     error ModuleManagerBase__ModuleAmountOverLimits();
 


### PR DESCRIPTION
## What has been done:
Removed both errors, as they are no longer relevant:
- The functionality of Module__LM_PC_KPIRewarder_v1__InvalidTargetValue() has been replaced by Module__LM_PC_KPIRewarder_v1__InvalidKPITrancheValues()
- We don't check module order anymore in the ModuleManager