### PR TITLE
[SC-556] Feat: Implement ProxyAdmin flow for self-governed module upgrades

### DIFF
--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -139,7 +139,7 @@ contract ModuleFactory_v1 is
         address proxy;
         //If the workflow should fetch their updates themselves
         if (workflowConfig.independentUpdates) {
-            //Use a InverterTransparentUpgradeableProxy as a proxy
+            //Use an InverterTransparentUpgradeableProxy as a proxy
             proxy = address(
                 new InverterTransparentUpgradeableProxy_v1(
                     beacon, workflowConfig.independentUpdateAdmin, bytes("")

--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -138,7 +138,7 @@ contract OrchestratorFactory_v1 is
         address proxy;
         //If the workflow should fetch their updates themselves
         if (workflowConfig.independentUpdates) {
-            //Use a InverterTransparentUpgradeableProxy as a proxy
+            //Use an InverterTransparentUpgradeableProxy as a proxy
             proxy = address(
                 new InverterTransparentUpgradeableProxy_v1(
                     beacon, workflowConfig.independentUpdateAdmin, bytes("")

--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -7,6 +7,7 @@ import {InverterBeaconProxy_v1} from "src/proxies/InverterBeaconProxy_v1.sol";
 import {InverterTransparentUpgradeableProxy_v1} from
     "src/proxies/InverterTransparentUpgradeableProxy_v1.sol";
 import {IInverterBeacon_v1} from "src/proxies/interfaces/IInverterBeacon_v1.sol";
+import {InverterProxyAdmin_v1} from "src/proxies/InverterProxyAdmin_v1.sol";
 
 // Internal Interfaces
 import {
@@ -138,6 +139,13 @@ contract OrchestratorFactory_v1 is
         address proxy;
         //If the workflow should fetch their updates themselves
         if (workflowConfig.independentUpdates) {
+            //Deploy a proxy admin contract that owns the invidual proxies
+            //Overwriting the independentUpdateAdmin as the ProxyAdmin will
+            //be the actual admin of the proxy
+            workflowConfig.independentUpdateAdmin = address(
+                new InverterProxyAdmin_v1(workflowConfig.independentUpdateAdmin)
+            );
+
             //Use an InverterTransparentUpgradeableProxy as a proxy
             proxy = address(
                 new InverterTransparentUpgradeableProxy_v1(

--- a/src/proxies/InverterProxyAdmin.sol
+++ b/src/proxies/InverterProxyAdmin.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity 0.8.23;
+
+//Internal Interfaces
+import {IInverterTransparentUpgradeableProxy_v1} from
+    "src/proxies/interfaces/IInverterTransparentUpgradeableProxy_v1.sol";
+
+// External Dependencies
+import {Ownable} from "@oz/access/Ownable.sol";
+import {Ownable2Step} from "@oz/access/Ownable2Step.sol";
+
+/**
+ * @title   Inverter Proxy Admin
+ *
+ * @notice  Manages upgrades for Inverter Network proxies, allowing administrators to update
+ *          the implementation logic of deployed contracts. Supports batch upgrades for multiple
+ *          proxies in a single transaction.
+ *
+ * @author  Inverter Network
+ */
+contract InverterProxyAdmin_v1 is Ownable2Step {
+    /**
+     * @dev Sets the initial owner who can perform upgrades.
+     */
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    /// @notice Upgrades the corresponding proxy to the newest version of the implementation.
+    /// @dev This contract must be othe admin/owner of the proxy.
+    /// @param proxy The proxy to upgrade.
+    function upgradeToNewestVersion(
+        IInverterTransparentUpgradeableProxy_v1 proxy
+    ) external onlyOwner {
+        proxy.upgradeToNewestVersion();
+    }
+
+    /// @notice Upgrades multiple proxies to the newest version of the implementation.
+    /// @dev This contract must be othe admin/owner of the proxies.
+    /// @param proxies The proxies to upgrade.
+    function upgradeToNewestVersionBatched(
+        IInverterTransparentUpgradeableProxy_v1[] calldata proxies
+    ) external onlyOwner {
+        for (uint i; i < proxies.length; i++) {
+            proxies[i].upgradeToNewestVersion();
+        }
+    }
+}

--- a/src/proxies/InverterProxyAdmin_v1.sol
+++ b/src/proxies/InverterProxyAdmin_v1.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.23;
 
 //Internal Interfaces
+import {IInverterProxyAdmin_v1} from
+    "src/proxies/interfaces/IInverterProxyAdmin_v1.sol";
 import {IInverterTransparentUpgradeableProxy_v1} from
     "src/proxies/interfaces/IInverterTransparentUpgradeableProxy_v1.sol";
 
@@ -17,23 +19,19 @@ import {Ownable2Step} from "@oz/access/Ownable2Step.sol";
  *
  * @author  Inverter Network
  */
-contract InverterProxyAdmin_v1 is Ownable2Step {
+contract InverterProxyAdmin_v1 is Ownable2Step, IInverterProxyAdmin_v1 {
     /// @notice Constructs the InverterProxyAdmin_v1.
     /// @param initialOwner The initial owner of the contract.
     constructor(address initialOwner) Ownable(initialOwner) {}
 
-    /// @notice Upgrades the corresponding proxy to the newest version of the implementation.
-    /// @dev This contract must be othe admin/owner of the proxy.
-    /// @param proxy The proxy to upgrade.
+    /// @inheritdoc IInverterProxyAdmin_v1
     function upgradeToNewestVersion(
         IInverterTransparentUpgradeableProxy_v1 proxy
     ) external onlyOwner {
         proxy.upgradeToNewestVersion();
     }
 
-    /// @notice Upgrades multiple proxies to the newest version of the implementation.
-    /// @dev This contract must be othe admin/owner of the proxies.
-    /// @param proxies The proxies to upgrade.
+    /// @inheritdoc IInverterProxyAdmin_v1
     function upgradeToNewestVersionBatched(
         IInverterTransparentUpgradeableProxy_v1[] calldata proxies
     ) external onlyOwner {

--- a/src/proxies/InverterProxyAdmin_v1.sol
+++ b/src/proxies/InverterProxyAdmin_v1.sol
@@ -35,7 +35,7 @@ contract InverterProxyAdmin_v1 is Ownable2Step, IInverterProxyAdmin_v1 {
     function upgradeToNewestVersionBatched(
         IInverterTransparentUpgradeableProxy_v1[] calldata proxies
     ) external onlyOwner {
-        for (uint i; i < proxies.length; i++) {
+        for (uint i; i < proxies.length; ++i) {
             proxies[i].upgradeToNewestVersion();
         }
     }

--- a/src/proxies/InverterProxyAdmin_v1.sol
+++ b/src/proxies/InverterProxyAdmin_v1.sol
@@ -12,16 +12,14 @@ import {Ownable2Step} from "@oz/access/Ownable2Step.sol";
 /**
  * @title   Inverter Proxy Admin
  *
- * @notice  Manages upgrades for Inverter Network proxies, allowing administrators to update
- *          the implementation logic of deployed contracts. Supports batch upgrades for multiple
- *          proxies in a single transaction.
+ * @notice  Acts as the admin of the Inverter Transparent Upgradeable Proxies
+ *          and is responsible for upgrading the proxies to the newest version.
  *
  * @author  Inverter Network
  */
 contract InverterProxyAdmin_v1 is Ownable2Step {
-    /**
-     * @dev Sets the initial owner who can perform upgrades.
-     */
+    /// @notice Constructs the InverterProxyAdmin_v1.
+    /// @param initialOwner The initial owner of the contract.
     constructor(address initialOwner) Ownable(initialOwner) {}
 
     /// @notice Upgrades the corresponding proxy to the newest version of the implementation.

--- a/src/proxies/interfaces/IInverterProxyAdmin_v1.sol
+++ b/src/proxies/interfaces/IInverterProxyAdmin_v1.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {IInverterTransparentUpgradeableProxy_v1} from
+    "./IInverterTransparentUpgradeableProxy_v1.sol";
+
+interface IInverterProxyAdmin_v1 {
+    /// @notice Upgrades the corresponding proxy to the newest version of the implementation.
+    /// @dev This contract must be othe admin/owner of the proxy.
+    /// @param proxy The proxy to upgrade.
+    function upgradeToNewestVersion(
+        IInverterTransparentUpgradeableProxy_v1 proxy
+    ) external;
+
+    /// @notice Upgrades multiple proxies to the newest version of the implementation.
+    /// @dev This contract must be othe admin/owner of the proxies.
+    /// @param proxies The proxies to upgrade.
+    function upgradeToNewestVersionBatched(
+        IInverterTransparentUpgradeableProxy_v1[] calldata proxies
+    ) external;
+}

--- a/test/factories/OrchestratorFactory_v1.t.sol
+++ b/test/factories/OrchestratorFactory_v1.t.sol
@@ -8,6 +8,7 @@ import {OrchestratorFactory_v1} from "src/factories/OrchestratorFactory_v1.sol";
 
 // External Interfaces
 import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+import {Ownable} from "@oz/access/Ownable.sol";
 
 // Internal Interfaces
 import {
@@ -151,11 +152,17 @@ contract OrchestratorFactoryV1Test is Test {
         );
 
         //Check that workflowConfig was properly forwarded
-        (bool independentUpdates, address independentUpdateAdmin) =
+        (bool independentUpdates, address independentUpdateProxyAdmin) =
             moduleFactory.givenWorkflowConfig();
 
         assertEq(workflowConfig.independentUpdates, independentUpdates);
-        assertEq(workflowConfig.independentUpdateAdmin, independentUpdateAdmin);
+        if (workflowConfig.independentUpdates) {
+            address independentUpdateAdmin =
+                Ownable(independentUpdateProxyAdmin).owner();
+            assertEq(
+                workflowConfig.independentUpdateAdmin, independentUpdateAdmin
+            );
+        }
 
         // Check that orchestrator's strorage correctly initialized.
         assertEq(orchestrator.orchestratorId(), 1);

--- a/test/proxies/InverterProxyAdmin.sol
+++ b/test/proxies/InverterProxyAdmin.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+
+// Internal Dependencies
+import {InverterProxyAdmin_v1} from "src/proxies/InverterProxyAdmin_v1.sol";
+import {InverterTransparentUpgradeableProxy_v1} from
+    "src/proxies/InverterTransparentUpgradeableProxy_v1.sol";
+import {
+    InverterBeacon_v1,
+    IInverterBeacon_v1
+} from "src/proxies/InverterBeacon_v1.sol";
+import {InverterBeaconProxy_v1} from "src/proxies/InverterBeaconProxy_v1.sol";
+
+// Internal Interfaces
+import {IInverterTransparentUpgradeableProxy_v1} from
+    "src/proxies/interfaces/IInverterTransparentUpgradeableProxy_v1.sol";
+
+// Mocks
+import {
+    InverterTransparentUpgradeableProxy_v1,
+    InverterTransparentUpgradeableProxyV1AccessMock
+} from
+    "test/utils/mocks/proxies/InverterTransparentUpgradeableProxyV1AccessMock.sol";
+import {InverterBeaconV1Mock} from
+    "test/utils/mocks/proxies/InverterBeaconV1Mock.sol";
+import {ModuleImplementationV1Mock} from
+    "test/utils/mocks/proxies/ModuleImplementationV1Mock.sol";
+import {ModuleImplementationV2Mock} from
+    "test/utils/mocks/proxies/ModuleImplementationV2Mock.sol";
+
+import {OZErrors} from "test/utils/errors/OZErrors.sol";
+
+contract InverterProxyAdmin is Test {
+    // SuT
+    InverterProxyAdmin_v1 proxyAdmin;
+    InverterTransparentUpgradeableProxy_v1 proxy;
+    InverterTransparentUpgradeableProxyV1AccessMock proxyMock;
+
+    // Mocks
+    InverterBeaconV1Mock beacon;
+    ModuleImplementationV1Mock implementation1;
+    ModuleImplementationV2Mock implementation2;
+
+    uint initialMajorVersion = 1;
+    uint initialMinorVersion = 0;
+
+    address admin = makeAddr("admin");
+
+    // ERC1967Utils
+    event AdminChanged(address previousAdmin, address newAdmin);
+
+    function setUp() public {
+        beacon = new InverterBeaconV1Mock();
+
+        implementation1 = new ModuleImplementationV1Mock();
+        implementation2 = new ModuleImplementationV2Mock();
+
+        beacon.overrideImplementation(address(implementation1));
+        beacon.overrideVersion(initialMajorVersion, initialMinorVersion);
+
+        proxyAdmin = new InverterProxyAdmin_v1(admin);
+        proxy = new InverterTransparentUpgradeableProxy_v1(
+            beacon, address(proxyAdmin), bytes("")
+        );
+
+        proxyMock = new InverterTransparentUpgradeableProxyV1AccessMock(
+            beacon, address(proxyAdmin), bytes("")
+        );
+    }
+
+    function testDeploymentInvariants() public {
+        beacon = new InverterBeaconV1Mock();
+
+        implementation1 = new ModuleImplementationV1Mock();
+        beacon.overrideImplementation(address(implementation1));
+        beacon.overrideVersion(initialMajorVersion, initialMinorVersion);
+
+        vm.expectEmit(true, true, true, true);
+        emit AdminChanged(address(0), address(proxyAdmin));
+
+        proxyMock = new InverterTransparentUpgradeableProxyV1AccessMock(
+            beacon, address(proxyAdmin), bytes("")
+        );
+
+        assertEq(proxyMock.direct__admin(), address(proxyAdmin));
+        assertEq(proxyMock.direct__beacon(), address(beacon));
+        assertEq(proxyMock.direct__implementation(), address(implementation1));
+        (uint returnedMajorVersion, uint returnedMinorVersion) =
+            proxyMock.version();
+        assertEq(returnedMajorVersion, initialMajorVersion);
+        assertEq(returnedMinorVersion, initialMinorVersion);
+    }
+
+    function testUpgradeToNewestVersionFailsIfNotAdmin(address user) public {
+        vm.assume(user != admin);
+
+        beacon.overrideImplementation(address(implementation2));
+        beacon.overrideVersion(initialMajorVersion + 1, initialMinorVersion + 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(OZErrors.Ownable__UnauthorizedAccount, user)
+        );
+
+        vm.prank(user);
+        proxyAdmin.upgradeToNewestVersion(
+            IInverterTransparentUpgradeableProxy_v1(address(proxyMock))
+        );
+
+        (uint returnedMajorVersion, uint returnedMinorVersion) =
+            proxyMock.version();
+        assertEq(returnedMajorVersion, initialMajorVersion);
+        assertEq(returnedMinorVersion, initialMinorVersion);
+    }
+
+    function testUpgradeToNewestVersion() public {
+        beacon.overrideImplementation(address(implementation2));
+        beacon.overrideVersion(initialMajorVersion + 1, initialMinorVersion + 1);
+
+        vm.prank(admin);
+        proxyAdmin.upgradeToNewestVersion(
+            IInverterTransparentUpgradeableProxy_v1(address(proxyMock))
+        );
+
+        (uint returnedMajorVersion, uint returnedMinorVersion) =
+            proxyMock.version();
+        assertEq(returnedMajorVersion, initialMajorVersion + 1);
+        assertEq(returnedMinorVersion, initialMinorVersion + 1);
+    }
+}


### PR DESCRIPTION
**Status**: ⌛ Done, pending reviews.

<hr> 

**User Story**
As a user, I want to be able to transfer the rights to upgrading my self-governed modules, and it should be easy, not needing to transfer each module one-by-one.

**Additional Context**
* Currently each modules proxy is owned by a immutable address.
* Also the admin of the proxies can't interact with the underlying module itself, due to the nature of the TransparentProxy
* Proposed Solution:
  * We wanna have it be owned by a ProxyAdmin, that is deployed upon workflow creation
  * All modules + orchestrator owned by that one ProxyAdmin