### PR TITLE
[SC-310] Bug(M-1): Inflated supply when redeeming issuance token on FM_BC

### DIFF
--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -182,8 +182,6 @@ abstract contract RedeemingBondingCurveBase_v1 is
 
         issuanceFeeAmount = protocolFeeAmount;
 
-        // Process the protocol fee
-        _processProtocolFeeViaMinting(issuanceTreasury, protocolFeeAmount);
         // Calculate redeem amount based on upstream formula
         uint collateralRedeemAmount = _redeemTokensFormulaWrapper(netDeposit);
 
@@ -191,6 +189,9 @@ abstract contract RedeemingBondingCurveBase_v1 is
 
         // Burn issued token from user
         _burn(_msgSender(), _depositAmount);
+
+        // Process the protocol fee. We can re-mint some of the burned tokens, since we aren't paying out the backing collateral
+        _processProtocolFeeViaMinting(issuanceTreasury, protocolFeeAmount);
 
         // Require that enough collateral token is held to be redeemable
         if (

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -189,10 +189,10 @@ abstract contract RedeemingBondingCurveBase_v1 is
 
         // Burn issued token from user
         _burn(_msgSender(), _depositAmount);
-        
+
         // Process the protocol fee. We can re-mint some of the burned tokens, since we aren't paying out the backing collateral
         _processProtocolFeeViaMinting(issuanceTreasury, protocolFeeAmount);
-        
+
         // Cache Collateral Token
         IERC20 collateralToken = __Module_orchestrator.fundingManager().token();
 


### PR DESCRIPTION
## What has been done
- Moved the processProtocolFee some lines down so we re-mint some of the burned tokens to the treasury. This avoids having to worry about allowances/balances