### PR TITLE
Fix: Make issuance token interface inherit IERC20

### DIFF
--- a/src/modules/fundingManager/bondingCurve/interfaces/IERC20Issuance_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/interfaces/IERC20Issuance_v1.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity 0.8.23;
 
-interface IERC20Issuance_v1 {
+import {IERC20} from "@oz/token/ERC20/IERC20.sol";
+
+interface IERC20Issuance_v1 is IERC20 {
     // Events
 
     /// @notice Emitted when the minter is set.


### PR DESCRIPTION
Currently the interface does not inherit the base IERC20 contract, this can make casting cumbersome when using only the interface. Since the implementation inherits ERC20, I think we can make the interface inherit it too.