### PR TITLE
[SC-557] Bug: Update state modifier BC functions used to calculate price

### DIFF
--- a/src/external/fees/interfaces/IFeeManager_v1.sol
+++ b/src/external/fees/interfaces/IFeeManager_v1.sol
@@ -143,7 +143,7 @@ interface IFeeManager_v1 {
         address workflow,
         address module,
         bytes4 functionSelector
-    ) external returns (uint fee, address treasury);
+    ) external view returns (uint fee, address treasury);
 
     /// @notice Returns the issuance fee for a specific workflow module function and the according treasury address of the workflow
     /// @param workflow The address of the workflow that contains the module function
@@ -155,7 +155,7 @@ interface IFeeManager_v1 {
         address workflow,
         address module,
         bytes4 functionSelector
-    ) external returns (uint fee, address treasury);
+    ) external view returns (uint fee, address treasury);
 
     //--------------------------------------------------------------------------
     // Setter Functions

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -226,6 +226,7 @@ abstract contract Module_v1 is
     /// @return treasury The address of the treasury
     function _getFeeManagerCollateralFeeData(bytes4 functionSelector)
         internal
+        view
         returns (uint fee, address treasury)
     {
         //Fetch fee manager address from orchestrator
@@ -244,6 +245,7 @@ abstract contract Module_v1 is
     /// @return treasury The address of the treasury
     function _getFeeManagerIssuanceFeeData(bytes4 functionSelector)
         internal
+        view
         returns (uint fee, address treasury)
     {
         //Fetch fee manager address from orchestrator

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -118,6 +118,7 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     /// @inheritdoc IBondingCurveBase_v1
     function calculatePurchaseReturn(uint _depositAmount)
         public
+        view
         virtual
         returns (uint mintAmount)
     {
@@ -184,7 +185,7 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     // Public Functions Implemented in Downstream Contract
 
     /// @inheritdoc IBondingCurveBase_v1
-    function getStaticPriceForBuying() external virtual returns (uint);
+    function getStaticPriceForBuying() external view virtual returns (uint);
 
     //--------------------------------------------------------------------------
     // Internal Functions Implemented in Downstream Contract
@@ -298,6 +299,7 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     ///     being deposited or minted, expressed in BPS
     function _getFunctionFeesAndTreasuryAddresses(bytes4 _selector)
         internal
+        view
         virtual
         returns (
             address collateralTreasury,

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -103,6 +103,7 @@ abstract contract RedeemingBondingCurveBase_v1 is
     /// @inheritdoc IRedeemingBondingCurveBase_v1
     function calculateSaleReturn(uint _depositAmount)
         public
+        view
         virtual
         returns (uint redeemAmount)
     {

--- a/src/modules/fundingManager/bondingCurve/interfaces/IBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/interfaces/IBondingCurveBase_v1.sol
@@ -126,7 +126,7 @@ interface IBondingCurveBase_v1 {
 
     /// @notice Calculates and returns the static price for buying the issuance token.
     /// @return uint The static price for buying the issuance token.
-    function getStaticPriceForBuying() external returns (uint);
+    function getStaticPriceForBuying() external view returns (uint);
 
     /// @notice Calculates the amount of tokens to be minted based on a given deposit amount.
     /// @dev This function takes into account any applicable buy fees before computing the

--- a/test/utils/mocks/external/FeeManagerV1Mock.sol
+++ b/test/utils/mocks/external/FeeManagerV1Mock.sol
@@ -39,13 +39,13 @@ contract FeeManagerV1Mock is IFeeManager_v1 {
         address workflow,
         address module,
         bytes4 functionSelector
-    ) external returns (uint fee, address treasury) {}
+    ) external view returns (uint fee, address treasury) {}
 
     function getIssuanceWorkflowFeeAndTreasury(
         address workflow,
         address module,
         bytes4 functionSelector
-    ) external returns (uint fee, address treasury) {}
+    ) external view returns (uint fee, address treasury) {}
 
     //--------------------------------------------------------------------------
     // Setter Functions


### PR DESCRIPTION
## Why
The function `calculateSaleReturn` and `calculatePurchaseReturn` had state modifiers signalling that a state would be changed. This would force the FE to simulate a call to the function instead of just reading it. This was a bug, as they don't change a state
## What has been done?
- Update state mutability for the functions `calculateSaleReturn` and `calculatePurchaseReturn` as well as all the functions they depended on which were incorrectly not set to view
