### PR TITLE
[SC-316] Bug(M-3): Resolved assertion reported as unresolved LM_PC_KPIRewarder

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -313,10 +313,11 @@ contract LM_PC_KPIRewarder_v1 is
         bytes32 assertionId,
         bool assertedTruthfully
     ) public override {
-        if (_msgSender() != address(oo)) {
-            revert Module__OptimisticOracleIntegrator__CallerNotOO();
-        }
 
+        //First, we perform checks and state management on the parent function.
+        super.assertionResolvedCallback(assertionId, assertedTruthfully);
+
+        // If the assertion was true, we calculate the rewards and distribute them.
         if (assertedTruthfully) {
             // SECURITY NOTE: this will add the value, but provides no guarantee that the fundingmanager actually holds those funds.
 
@@ -356,14 +357,10 @@ contract LM_PC_KPIRewarder_v1 is
             }
 
             _setRewards(rewardAmount, 1);
-        }
-        emit DataAssertionResolved(
-            assertedTruthfully,
-            assertionData[assertionId].dataId,
-            assertionData[assertionId].data,
-            assertionData[assertionId].asserter,
-            assertionId
-        );
+            assertionConfig[assertionId].distributed = true;
+
+        } 
+        // If the data assertion resolved to false, the 'distributed' value in assertionConfig will stay false
     }
 
     /// @inheritdoc OptimisticOracleV3CallbackRecipientInterface

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -313,7 +313,6 @@ contract LM_PC_KPIRewarder_v1 is
         bytes32 assertionId,
         bool assertedTruthfully
     ) public override {
-
         //First, we perform checks and state management on the parent function.
         super.assertionResolvedCallback(assertionId, assertedTruthfully);
 
@@ -358,9 +357,10 @@ contract LM_PC_KPIRewarder_v1 is
 
             _setRewards(rewardAmount, 1);
             assertionConfig[assertionId].distributed = true;
-
-        } 
-        // If the data assertion resolved to false, the 'distributed' value in assertionConfig will stay false
+        } else {
+            // To keep in line with the upstream contract. If the assertion was false, we delete the corresponding assertionConfig from storage.
+            delete assertionConfig[assertionId];
+        }
     }
 
     /// @inheritdoc OptimisticOracleV3CallbackRecipientInterface

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -879,6 +879,10 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         );
         kpiManager.assertionResolvedCallback(createdID, false);
         vm.stopPrank();
+
+        // Check assertion data is deleted
+        assertEq(kpiManager.getAssertion(createdID).dataId, 0);
+        assertEq(kpiManager.getAssertionConfig(createdID).creationTime, 0);
     }
 
     modifier whenTheAssertionResolvedToTrue() {
@@ -906,9 +910,6 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         vm.startPrank(address(ooV3));
 
         vm.expectEmit(true, true, true, true, address(kpiManager));
-        emit RewardSet(250e18, 1, 250e18, block.timestamp + 1);
-
-        vm.expectEmit(true, true, true, true, address(kpiManager));
         emit DataAssertionResolved(
             true,
             MOCK_ASSERTION_DATA_ID,
@@ -917,8 +918,15 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
             createdID
         );
 
+        vm.expectEmit(true, true, true, true, address(kpiManager));
+        emit RewardSet(250e18, 1, 250e18, block.timestamp + 1);
+
         kpiManager.assertionResolvedCallback(createdID, true);
         vm.stopPrank();
+
+        // Check storage state is modified
+        assertEq(kpiManager.getAssertion(createdID).resolved, true);
+        assertEq(kpiManager.getAssertionConfig(createdID).distributed, true);
 
         vm.warp(block.timestamp + 3);
 
@@ -982,9 +990,6 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         vm.startPrank(address(ooV3));
 
         vm.expectEmit(true, true, true, true, address(kpiManager));
-        emit RewardSet(200e18, 1, 200e18, block.timestamp + 1);
-
-        vm.expectEmit(true, true, true, true, address(kpiManager));
         emit DataAssertionResolved(
             true,
             MOCK_ASSERTION_DATA_ID,
@@ -993,9 +998,15 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
             createdID
         );
 
+        vm.expectEmit(true, true, true, true, address(kpiManager));
+        emit RewardSet(200e18, 1, 200e18, block.timestamp + 1);
+
         kpiManager.assertionResolvedCallback(createdID, true);
         vm.stopPrank();
 
+        // Check storage state is modified
+        assertEq(kpiManager.getAssertion(createdID).resolved, true);
+        assertEq(kpiManager.getAssertionConfig(createdID).distributed, true);
         vm.warp(block.timestamp + 3);
 
         uint length = users.length;

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -881,7 +881,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         vm.stopPrank();
 
         // Check assertion data is deleted
-        assertEq(kpiManager.getAssertion(createdID).dataId, 0);
+        assertEq(kpiManager.getAssertion(createdID).asserter, address(0)); // address(0) asserters are not possible in the system
         assertEq(kpiManager.getAssertionConfig(createdID).creationTime, 0);
     }
 


### PR DESCRIPTION
## What has been done
- Modified assertionResolvedCallback() function to start by calling the upstream implementation. 
- assertionResolvedCallback() now also deletes assertionConfig state data if the assertion has been deemed fraudulent.
- Updated tests to the new event emit order