### PR TITLE
[SC-497] Bug(M-5): Queued stakers can receive rewards from pending assertions

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -374,7 +374,6 @@ contract LM_PC_KPIRewarder_v1 is
 
         // Independently of the fact that the assertion resolved true or not, new assertions can now be posted.
         assertionPending = false;
-
     }
 
     /// @inheritdoc OptimisticOracleV3CallbackRecipientInterface

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -52,6 +52,9 @@ interface ILM_PC_KPIRewarder_v1 {
     /// @notice The Token used paying the bond cannot be the same that is being staked.
     error Module__LM_PC_KPIRewarder_v1__ModuleCannotUseStakingTokenAsBond();
 
+    /// @notice An assertion can only by posted if the preceding one is resolved.
+    error Module__LM_PC_KPIRewarder_v1__UnresolvedAssertionExists();
+
     //--------------------------------------------------------------------------
     // Events
 

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -268,6 +268,8 @@ postAssertionTest
 │   └── it should revert 
 ├── when the specified KPI does not exist
 │   └── it should revert 
+├── when there is an unresolved assertion live
+│   └── it should revert 
 ├── when stakingQueue length is bigger than 0
 │   ├── it should stake all orders in the stakingQueue
 │   └── it should remove the amount form the queued funds
@@ -341,6 +343,63 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
             100,
             99_999
         );
+    }
+
+    function test_RevertWhen_ThereIsALiveUnresolvedAssertion() external {
+        // prepare conditions
+        createDummyIncontinuousKPI();
+
+        // prepare  bond and asserter authorization
+        kpiManager.grantModuleRole(
+            kpiManager.ASSERTER_ROLE(), MOCK_ASSERTER_ADDRESS
+        );
+        feeToken.mint(
+            address(MOCK_ASSERTER_ADDRESS),
+            ooV3.getMinimumBond(address(feeToken))
+        ); //
+        vm.startPrank(address(MOCK_ASSERTER_ADDRESS));
+        feeToken.approve(
+            address(kpiManager), ooV3.getMinimumBond(address(feeToken))
+        );
+        vm.stopPrank();
+
+        // SuT
+        vm.expectEmit(true, false, false, false, address(kpiManager));
+        emit DataAsserted(
+            MOCK_ASSERTION_DATA_ID,
+            MOCK_ASSERTION_DATA,
+            MOCK_ASSERTER_ADDRESS,
+            0x0
+        );
+        vm.prank(address(MOCK_ASSERTER_ADDRESS));
+        bytes32 assertionId = kpiManager.postAssertion(
+            MOCK_ASSERTION_DATA_ID,
+            MOCK_ASSERTION_DATA,
+            MOCK_ASSERTER_ADDRESS,
+            100,
+            0
+        );
+
+        // state after
+        assertEq(kpiManager.assertionPending(), true);
+
+        // Posting another assertion should now fail
+        vm.expectRevert(
+            ILM_PC_KPIRewarder_v1
+                .Module__LM_PC_KPIRewarder_v1__UnresolvedAssertionExists
+                .selector
+        );
+        vm.prank(address(MOCK_ASSERTER_ADDRESS));
+        assertionId = kpiManager.postAssertion(
+            MOCK_ASSERTION_DATA_ID,
+            MOCK_ASSERTION_DATA,
+            MOCK_ASSERTER_ADDRESS,
+            100,
+            0
+        );
+
+        // created one is still pending
+        assertEq(kpiManager.assertionPending(), true);
     }
 
     function test_WhenStakingQueueLengthIsBiggerThan0(


### PR DESCRIPTION
## What has been done
- Added a boolean check if there is already a live assertion posted and revert in that case
- Added corresponding error