### PR TITLE
[Sc-479] Bug(M-6): Asserter can post invalid assertions with minimal penalty

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -96,12 +96,15 @@ contract LM_PC_KPIRewarder_v1 is
         (
             address stakingTokenAddr,
             address currencyAddr,
+            uint defaultBond,
             address ooAddr,
             uint64 liveness
-        ) = abi.decode(configData, (address, address, address, uint64));
+        ) = abi.decode(configData, (address, address, uint, address, uint64));
 
         __LM_PC_Staking_v1_init(stakingTokenAddr);
-        __OptimisticOracleIntegrator_init(currencyAddr, ooAddr, liveness);
+        __OptimisticOracleIntegrator_init(
+            currencyAddr, defaultBond, ooAddr, liveness
+        );
     }
 
     // ======================================================================

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/IOptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/IOptimisticOracleIntegrator.sol
@@ -77,7 +77,8 @@ interface IOptimisticOracleIntegrator is
     /// @notice Sets the default currency and amount for the bond.
     /// @param _newCurrency The address of the new default currency.
     /// @param _newBond The new bond amount.
-    function setDefaultCurrencyAndBond(address _newCurrency, uint _newBond) external;
+    function setDefaultCurrencyAndBond(address _newCurrency, uint _newBond)
+        external;
 
     /// @notice Sets the OptimisticOracleV3 instance where assertions will be published to.
     /// @param _newOO The address of the new OptimisticOracleV3 instance.

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/IOptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/IOptimisticOracleIntegrator.sol
@@ -47,6 +47,9 @@ interface IOptimisticOracleIntegrator is
     /// @notice Caller is not Optimistic Oracle instance
     error Module__OptimisticOracleIntegrator__CallerNotOO();
 
+    /// @notice Bond given for the specified currency is below minimum
+    error Module__OptimisticOracleIntegrator__CurrencyBondTooLow();
+
     //==========================================================================
     // Functions
 
@@ -71,9 +74,10 @@ interface IOptimisticOracleIntegrator is
 
     // Setter Functions
 
-    /// @notice Sets the default currency for the bond.
+    /// @notice Sets the default currency and amount for the bond.
     /// @param _newCurrency The address of the new default currency.
-    function setDefaultCurrency(address _newCurrency) external;
+    /// @param _newBond The new bond amount.
+    function setDefaultCurrency(address _newCurrency, uint _newBond) external;
 
     /// @notice Sets the OptimisticOracleV3 instance where assertions will be published to.
     /// @param _newOO The address of the new OptimisticOracleV3 instance.

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/IOptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/IOptimisticOracleIntegrator.sol
@@ -77,7 +77,7 @@ interface IOptimisticOracleIntegrator is
     /// @notice Sets the default currency and amount for the bond.
     /// @param _newCurrency The address of the new default currency.
     /// @param _newBond The new bond amount.
-    function setDefaultCurrency(address _newCurrency, uint _newBond) external;
+    function setDefaultCurrencyAndBond(address _newCurrency, uint _newBond) external;
 
     /// @notice Sets the OptimisticOracleV3 instance where assertions will be published to.
     /// @param _newOO The address of the new OptimisticOracleV3 instance.

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -73,7 +73,7 @@ abstract contract OptimisticOracleIntegrator is
     ) internal onlyInitializing {
         _setOptimisticOracle(ooAddr);
         _setDefaultAssertionLiveness(liveness);
-        _setDefaultCurrency(currencyAddr, bondAmount);
+        _setDefaultCurrencyAndBond(currencyAddr, bondAmount);
     }
 
     //--------------------------------------------------------------------------
@@ -98,11 +98,11 @@ abstract contract OptimisticOracleIntegrator is
     // Setter Functions
 
     /// @inheritdoc IOptimisticOracleIntegrator
-    function setDefaultCurrency(address _newCurrency, uint _newBond)
+    function setDefaultCurrencyAndBond(address _newCurrency, uint _newBond)
         public
         onlyOrchestratorOwner
     {
-        _setDefaultCurrency(_newCurrency, _newBond);
+        _setDefaultCurrencyAndBond(_newCurrency, _newBond);
     }
 
     /// @inheritdoc IOptimisticOracleIntegrator
@@ -121,7 +121,7 @@ abstract contract OptimisticOracleIntegrator is
     //==========================================================================
     // Internal Functions
 
-    function _setDefaultCurrency(address _newCurrency, uint _newBond)
+    function _setDefaultCurrencyAndBond(address _newCurrency, uint _newBond)
         internal
     {
         if (address(_newCurrency) == address(0)) {

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity 0.8.23;
 
-import "forge-std/console.sol";
-
 // Internal Dependencies
 import {Module_v1} from "src/modules/base/Module_v1.sol";
 
@@ -40,6 +38,7 @@ abstract contract OptimisticOracleIntegrator is
 
     // General Parameters
     IERC20 public defaultCurrency; // The currency used for the bond.
+    uint public defaultBond; // The bond used for the assertions. Must be higher or equal to the minimum bond of the currency used
     OptimisticOracleV3Interface public oo; // The OptimisticOracleV3 instance where assertions will be published to.
     uint64 public assertionLiveness; // Time period an assertion is open for dispute (in seconds).
     bytes32 public defaultIdentifier; // The identifier used when creating the assertion. For most usecases, this will resolve to "ASSERT_TRUTH".
@@ -58,20 +57,23 @@ abstract contract OptimisticOracleIntegrator is
     ) external virtual override initializer {
         __Module_init(orchestrator_, metadata);
 
-        (address currencyAddr, address ooAddr, uint64 liveness) =
-            abi.decode(configData, (address, address, uint64));
+        (address currencyAddr, uint bondAmount, address ooAddr, uint64 liveness)
+        = abi.decode(configData, (address, uint, address, uint64));
 
-        __OptimisticOracleIntegrator_init(currencyAddr, ooAddr, liveness);
+        __OptimisticOracleIntegrator_init(
+            currencyAddr, bondAmount, ooAddr, liveness
+        );
     }
 
     function __OptimisticOracleIntegrator_init(
         address currencyAddr,
+        uint bondAmount,
         address ooAddr,
         uint64 liveness
     ) internal onlyInitializing {
-        _setDefaultCurrency(currencyAddr);
         _setOptimisticOracle(ooAddr);
         _setDefaultAssertionLiveness(liveness);
+        _setDefaultCurrency(currencyAddr, bondAmount);
     }
 
     //--------------------------------------------------------------------------
@@ -96,11 +98,11 @@ abstract contract OptimisticOracleIntegrator is
     // Setter Functions
 
     /// @inheritdoc IOptimisticOracleIntegrator
-    function setDefaultCurrency(address _newCurrency)
+    function setDefaultCurrency(address _newCurrency, uint _newBond)
         public
         onlyOrchestratorOwner
     {
-        _setDefaultCurrency(_newCurrency);
+        _setDefaultCurrency(_newCurrency, _newBond);
     }
 
     /// @inheritdoc IOptimisticOracleIntegrator
@@ -119,15 +121,18 @@ abstract contract OptimisticOracleIntegrator is
     //==========================================================================
     // Internal Functions
 
-    function _setDefaultCurrency(address _newCurrency, uint _newBond) internal {
+    function _setDefaultCurrency(address _newCurrency, uint _newBond)
+        internal
+    {
         if (address(_newCurrency) == address(0)) {
             revert Module__OptimisticOracleIntegrator__InvalidDefaultCurrency();
         }
-        if( _newBond < oo.getMinimumBond(address(defaultCurrency));
+        if (_newBond < oo.getMinimumBond(address(_newCurrency))) {
+            revert Module__OptimisticOracleIntegrator__CurrencyBondTooLow();
+        }
 
-        // TODO expand this to include bond, and check that it is above the minimum bond.
-        // Will need refactoring of scripts and tests.
         defaultCurrency = IERC20(_newCurrency);
+        defaultBond = _newBond;
     }
 
     function _setOptimisticOracle(address _newOO) internal {
@@ -160,9 +165,10 @@ abstract contract OptimisticOracleIntegrator is
         returns (bytes32 assertionId)
     {
         asserter = asserter == address(0) ? _msgSender() : asserter;
-        uint bond = oo.getMinimumBond(address(defaultCurrency));
-        defaultCurrency.safeTransferFrom(_msgSender(), address(this), bond);
-        defaultCurrency.safeIncreaseAllowance(address(oo), bond);
+        defaultCurrency.safeTransferFrom(
+            _msgSender(), address(this), defaultBond
+        );
+        defaultCurrency.safeIncreaseAllowance(address(oo), defaultBond);
 
         // The claim we want to assert is the first argument of assertTruth. It must contain all of the relevant
         // details so that anyone may verify the claim without having to read any further information on chain. As a
@@ -189,7 +195,7 @@ abstract contract OptimisticOracleIntegrator is
             address(0), // No sovereign security.
             assertionLiveness,
             defaultCurrency,
-            bond,
+            defaultBond,
             defaultIdentifier,
             bytes32(0) // No domain.
         );

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -119,10 +119,14 @@ abstract contract OptimisticOracleIntegrator is
     //==========================================================================
     // Internal Functions
 
-    function _setDefaultCurrency(address _newCurrency) internal {
+    function _setDefaultCurrency(address _newCurrency, uint _newBond) internal {
         if (address(_newCurrency) == address(0)) {
             revert Module__OptimisticOracleIntegrator__InvalidDefaultCurrency();
         }
+        if( _newBond < oo.getMinimumBond(address(defaultCurrency));
+
+        // TODO expand this to include bond, and check that it is above the minimum bond.
+        // Will need refactoring of scripts and tests.
         defaultCurrency = IERC20(_newCurrency);
     }
 

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -196,6 +196,9 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
                 abi.encode(
                     address(stakingToken),
                     USDC_address,
+                    OptimisticOracleV3Interface(ooV3_address).getMinimumBond(
+                        USDC_address
+                    ),
                     ooV3_address,
                     ASSERTION_LIVENESS
                 ),

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -105,7 +105,11 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
         _authorizer.setIsAuthorized(address(this), true);
 
         bytes memory configData = abi.encode(
-            address(stakingToken), address(feeToken), ooV3, DEFAULT_LIVENESS
+            address(stakingToken),
+            address(feeToken),
+            ooV3.getMinimumBond(address(feeToken)),
+            ooV3,
+            DEFAULT_LIVENESS
         );
 
         kpiManager.init(_orchestrator, _METADATA, configData);

--- a/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
+++ b/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
@@ -184,6 +184,7 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
         uint minimumBond,
         uint proposedBond
     ) public {
+        minimumBond = bound(minimumBond, 0, 1e40); // keep it reasonable to avoid overflows
         vm.assume(proposedBond < minimumBond);
 
         _validateAddress(whitelisted); // make sure it doesn't collide with addresses in use by the test

--- a/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
+++ b/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
@@ -170,7 +170,9 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
 
     */
 
-    function testsetDefaultCurrencyAndBondFails_whenNewCurrencyIsZero() public {
+    function testsetDefaultCurrencyAndBondFails_whenNewCurrencyIsZero()
+        public
+    {
         vm.expectRevert(
             IOptimisticOracleIntegrator
                 .Module__OptimisticOracleIntegrator__InvalidDefaultCurrency
@@ -198,7 +200,9 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
         ooIntegrator.setDefaultCurrencyAndBond(whitelisted, proposedBond);
     }
 
-    function testsetDefaultCurrencyAndBond(address whitelisted, uint bond) public {
+    function testsetDefaultCurrencyAndBond(address whitelisted, uint bond)
+        public
+    {
         _validateAddress(whitelisted); // make sure it doesn't collide with addresses in use by the test
 
         ooV3.whitelistCurrency(whitelisted, 0);

--- a/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
+++ b/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
@@ -58,12 +58,17 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
 
         assertEq(address(_authorizer), address(_orchestrator.authorizer()));
 
-        //console.log("Token address: ", address(_token));
-        //console.log("Optimistic Oracle address: ",address(ooV3));
-        bytes memory _configData =
-            abi.encode(address(_token), address(ooV3), DEFAULT_LIVENESS);
-        //console.log("Optimistic Oracle config data (next line): ");
-        //console.logBytes(_configData);
+        console.log("Token address: ", address(_token));
+        console.log("Optimistic Oracle address: ", address(ooV3));
+        console.log("Minimum bond: ", ooV3.getMinimumBond(address(_token)));
+        bytes memory _configData = abi.encode(
+            address(_token),
+            ooV3.getMinimumBond(address(_token)),
+            address(ooV3),
+            DEFAULT_LIVENESS
+        );
+        console.log("Optimistic Oracle config data (next line): ");
+        console.logBytes(_configData);
 
         ooIntegrator.init(_orchestrator, _METADATA, _configData);
         _token.mint(address(this), 1e22);
@@ -154,8 +159,11 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
         When the caller is the owner
             when the address is 0
                 reverts
+            when the bond is below the minimum specified by the OptimisticOracleV3
+                reverts
             when the address is a valid token
                 sets the new address as default currency
+                sets the new bond amount
                 emits an event
         
         // Note: checks if the token is whitelisted in the OptimisticOracleV3 are performed when creating an assertion, not when setting the default currency
@@ -168,17 +176,36 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
                 .Module__OptimisticOracleIntegrator__InvalidDefaultCurrency
                 .selector
         );
-        ooIntegrator.setDefaultCurrency(address(0));
+        ooIntegrator.setDefaultCurrency(address(0), 0);
     }
 
-    function testSetDefaultCurrency(address whitelisted) public {
+    function testSetDefaultCurrencyFails_whenBondBelowMinimum(
+        address whitelisted,
+        uint minimumBond,
+        uint proposedBond
+    ) public {
+        vm.assume(proposedBond < minimumBond);
+
+        _validateAddress(whitelisted); // make sure it doesn't collide with addresses in use by the test
+        ooV3.whitelistCurrency(whitelisted, minimumBond);
+
+        vm.expectRevert(
+            IOptimisticOracleIntegrator
+                .Module__OptimisticOracleIntegrator__CurrencyBondTooLow
+                .selector
+        );
+        ooIntegrator.setDefaultCurrency(whitelisted, proposedBond);
+    }
+
+    function testSetDefaultCurrency(address whitelisted, uint bond) public {
         _validateAddress(whitelisted); // make sure it doesn't collide with addresses in use by the test
 
         ooV3.whitelistCurrency(whitelisted, 0);
 
-        ooIntegrator.setDefaultCurrency(whitelisted);
+        ooIntegrator.setDefaultCurrency(whitelisted, bond);
 
         assertEq(address(ooIntegrator.defaultCurrency()), whitelisted);
+        assertEq(ooIntegrator.defaultBond(), bond);
     }
 
     /*

--- a/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
+++ b/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
@@ -170,16 +170,16 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
 
     */
 
-    function testSetDefaultCurrencyFails_whenNewCurrencyIsZero() public {
+    function testsetDefaultCurrencyAndBondFails_whenNewCurrencyIsZero() public {
         vm.expectRevert(
             IOptimisticOracleIntegrator
                 .Module__OptimisticOracleIntegrator__InvalidDefaultCurrency
                 .selector
         );
-        ooIntegrator.setDefaultCurrency(address(0), 0);
+        ooIntegrator.setDefaultCurrencyAndBond(address(0), 0);
     }
 
-    function testSetDefaultCurrencyFails_whenBondBelowMinimum(
+    function testsetDefaultCurrencyAndBondFails_whenBondBelowMinimum(
         address whitelisted,
         uint minimumBond,
         uint proposedBond
@@ -195,15 +195,15 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
                 .Module__OptimisticOracleIntegrator__CurrencyBondTooLow
                 .selector
         );
-        ooIntegrator.setDefaultCurrency(whitelisted, proposedBond);
+        ooIntegrator.setDefaultCurrencyAndBond(whitelisted, proposedBond);
     }
 
-    function testSetDefaultCurrency(address whitelisted, uint bond) public {
+    function testsetDefaultCurrencyAndBond(address whitelisted, uint bond) public {
         _validateAddress(whitelisted); // make sure it doesn't collide with addresses in use by the test
 
         ooV3.whitelistCurrency(whitelisted, 0);
 
-        ooIntegrator.setDefaultCurrency(whitelisted, bond);
+        ooIntegrator.setDefaultCurrencyAndBond(whitelisted, bond);
 
         assertEq(address(ooIntegrator.defaultCurrency()), whitelisted);
         assertEq(ooIntegrator.defaultBond(), bond);


### PR DESCRIPTION
## What has been done
- Added the possibility to manually set the required Bond when setting the currency (enforcing it to be higher or equal to the minimum). This way users can set a higher one if they believe the funds at stake merit it.
- Adapted corresponding init functions and tests