### PR TITLE
[SC-503] Bug(H-8): Attacker may DoS KPI rewarder by filling out the staking queue

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -61,6 +61,7 @@ contract LM_PC_KPIRewarder_v1 is
     mapping(bytes32 => RewardRoundConfiguration) public assertionConfig;
 
     // Deposit Queue
+    uint minimumStake; // The workflow owner can set a minimum stake amount to mitigate griefing attacks where sybils spam the queue with multiple small stakes.
     address[] public stakingQueue;
     mapping(address => uint) public stakingQueueAmounts;
     uint public totalQueuedFunds;
@@ -250,6 +251,13 @@ contract LM_PC_KPIRewarder_v1 is
         return (KpiNum);
     }
 
+    function setMinimumStake(uint _minimumStake)
+        external
+        onlyOrchestratorOwner
+    {
+        minimumStake = _minimumStake;
+    }
+
     // ===========================================================
     // New user facing functions (stake() is a LM_PC_Staking_v1 override) :
 
@@ -262,6 +270,10 @@ contract LM_PC_KPIRewarder_v1 is
     {
         if (stakingQueue.length >= MAX_QUEUE_LENGTH) {
             revert Module__LM_PC_KPIRewarder_v1__StakingQueueIsFull();
+        }
+
+        if (amount < minimumStake) {
+            revert Module__LM_PC_KPIRewarder_v1__InvalidStakeAmount();
         }
 
         address sender = _msgSender();

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -51,7 +51,7 @@ interface ILM_PC_KPIRewarder_v1 {
 
     /// @notice The Token used paying the bond cannot be the same that is being staked.
     error Module__LM_PC_KPIRewarder_v1__ModuleCannotUseStakingTokenAsBond();
-    
+
     /// @notice The stake amount is invalid
     error Module__LM_PC_KPIRewarder_v1__InvalidStakeAmount();
 

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -52,6 +52,9 @@ interface ILM_PC_KPIRewarder_v1 {
     /// @notice The Token used paying the bond cannot be the same that is being staked.
     error Module__LM_PC_KPIRewarder_v1__ModuleCannotUseStakingTokenAsBond();
 
+    /// @notice The stake amount is invalid
+    error Module__LM_PC_KPIRewarder_v1__InvalidStakeAmount();
+
     //--------------------------------------------------------------------------
     // Events
 
@@ -122,4 +125,8 @@ interface ILM_PC_KPIRewarder_v1 {
         external
         view
         returns (RewardRoundConfiguration memory);
+
+    /// @notice Sets the minimum amount a user must stake
+    /// @param _minimumStake The minimum amount
+    function setMinimumStake(uint _minimumStake) external;
 }

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -679,6 +679,8 @@ contract LM_PC_KPIRewarder_v1_createKPITest is LM_PC_KPIRewarder_v1Test {
 stakeTest
 ├── when the staked amount is 0
 │   └── it should revert
+├── when the staked amount is below the minimum stake
+│   └── it should revert
 ├── when the length of the staking Queue is already at MAX_QUEUE_LENGTH
 │   └── it should revert
 ├── when the caller does not have sufficient funds
@@ -699,6 +701,27 @@ contract LM_PC_KPIRewarder_v1_stakeTest is LM_PC_KPIRewarder_v1Test {
                 .selector
         );
         kpiManager.stake(0);
+    }
+
+    function test_RevertWhen_TheStakedAmountIsBelowMinimum(
+        uint minAmount,
+        uint stakeAmount
+    ) external {
+        // it should revert
+        vm.assume(minAmount > 1);
+        stakeAmount = bound(stakeAmount, 1, minAmount - 1);
+
+        kpiManager.setMinimumStake(minAmount);
+
+        stakingToken.mint(USER_1, stakeAmount);
+        vm.startPrank(USER_1);
+        stakingToken.approve(address(kpiManager), stakeAmount);
+        vm.expectRevert(
+            ILM_PC_KPIRewarder_v1
+                .Module__LM_PC_KPIRewarder_v1__InvalidStakeAmount
+                .selector
+        );
+        kpiManager.stake(stakeAmount);
     }
 
     function test_RevertWhen_TheLengthOfTheStakingQueueIsAlreadyAtMAX_QUEUE_LENGTH(


### PR DESCRIPTION
## What has been done
- Added a minimum stake requirement to the stake functions. It starts out at zero, but the workflow owner can increase it if they deem it necessary
- Updated tests