### PR TITLE
[Sc-558] Add RewardRoundConfigured Event

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -184,6 +184,10 @@ contract LM_PC_KPIRewarder_v1 is
             block.timestamp, assertedValue, targetKPI, false
         );
 
+        emit RewardRoundConfigured(
+            assertionId, block.timestamp, assertedValue, targetKPI
+        );
+
         // (return assertionId)
     }
 

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -92,6 +92,13 @@ interface ILM_PC_KPIRewarder_v1 {
         uint[] trancheRewards
     );
 
+    event RewardRoundConfigured(
+        bytes32 indexed assertionId,
+        uint creationTime,
+        uint assertedValue,
+        uint indexed KpiToUse
+    );
+
     /// @notice Event emitted when funds for paying the bonding fee are deposited into the contract
     event FeeFundsDeposited(address token, uint amount);
 

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -84,6 +84,13 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
         uint[] trancheRewards
     );
 
+    event RewardRoundConfigured(
+        bytes32 indexed assertionId,
+        uint creationTime,
+        uint assertedValue,
+        uint indexed KpiToUse
+    );
+
     event PaymentOrderAdded(
         address indexed recipient, address indexed token, uint amount
     );
@@ -382,6 +389,9 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
             0x0
         ); //we don't know the last one
 
+        vm.expectEmit(false, true, true, true, address(kpiManager));
+        emit RewardRoundConfigured(0x0, block.timestamp, 100, 0); //we don't know the generated ID
+
         bytes32 assertionId = kpiManager.postAssertion(
             MOCK_ASSERTION_DATA_ID,
             MOCK_ASSERTION_DATA,
@@ -443,6 +453,10 @@ contract LM_PC_KPIRewarder_v1_postAssertionTest is LM_PC_KPIRewarder_v1Test {
             MOCK_ASSERTER_ADDRESS,
             0x0
         );
+
+        vm.expectEmit(false, true, true, true, address(kpiManager));
+        emit RewardRoundConfigured(0x0, block.timestamp, 100, 0); //we don't know the generated ID
+
         vm.prank(address(MOCK_ASSERTER_ADDRESS));
         bytes32 assertionId = kpiManager.postAssertion(
             MOCK_ASSERTION_DATA_ID,


### PR DESCRIPTION
## What has been done
- Added an additional event (RewardRoundConfigured) to the KPIRewarder. Following the audit fixes we will remove assertions which resolved to false, so this should help indexers to reconstruct the timeline in the future