### PR TITLE
[SC-476] Bug: Fix grantModuleRole bug

### DIFF
--- a/src/factories/interfaces/IOrchestratorFactory_v1.sol
+++ b/src/factories/interfaces/IOrchestratorFactory_v1.sol
@@ -21,8 +21,8 @@ interface IOrchestratorFactory_v1 {
     /// @notice The module's data arrays length mismatch.
     error OrchestratorFactory__ModuleDataLengthMismatch();
 
-    /// @notice The orchestrator owner is address(0)
-    error OrchestratorFactory__OrchestratorOwnerIsInvalid();
+    /// @notice The orchestrator admin is address(0)
+    error OrchestratorFactory__OrchestratorAdminIsInvalid();
 
     //--------------------------------------------------------------------------
     // Events
@@ -50,7 +50,7 @@ interface IOrchestratorFactory_v1 {
     //--------------------------------------------------------------------------
     // Functions
 
-    /// @notice Creates a new orchestrator_v1 with caller being the orchestrator's owner.
+    /// @notice Creates a new orchestrator_v1.
     /// @param workflowConfig The workflow's config data.
     /// @param authorizerConfig The config data for the orchestrator's {IAuthorizer_v1}
     ///                         instance.

--- a/src/modules/authorizer/IAuthorizer_v1.sol
+++ b/src/modules/authorizer/IAuthorizer_v1.sol
@@ -14,8 +14,8 @@ interface IAuthorizer_v1 is IAccessControlEnumerable {
     /// @notice The function is only callable if the Module is self-managing its roles.
     error Module__Authorizer__ModuleNotSelfManaged();
 
-    /// @notice There always needs to be at least one owner.
-    error Module__Authorizer__OwnerRoleCannotBeEmpty();
+    /// @notice There always needs to be at least one admin.
+    error Module__Authorizer__AdminRoleCannotBeEmpty();
 
     //--------------------------------------------------------------------------
     // Functions
@@ -76,32 +76,32 @@ interface IAuthorizer_v1 is IAccessControlEnumerable {
     /// @notice Grants a global role to a target
     /// @param role The role to grant
     /// @param target The address to grant the role to
-    /// @dev Only the addresses with the Owner role should be able to call this function
+    /// @dev Only the addresses with the Admin role should be able to call this function
     function grantGlobalRole(bytes32 role, address target) external;
 
     /// @notice Grants a global role to a set of targets
     /// @param role The role to grant
     /// @param targets The addresses to grant the role to
-    /// @dev Only the addresses with the Owner role should be able to call this function
+    /// @dev Only the addresses with the Admin role should be able to call this function
     function grantGlobalRoleBatched(bytes32 role, address[] calldata targets)
         external;
 
     /// @notice Revokes a global role from a target
     /// @param role The role to grant
     /// @param target The address to grant the role to
-    /// @dev Only the addresses with the Owner role should be able to call this function
+    /// @dev Only the addresses with the Admin role should be able to call this function
     function revokeGlobalRole(bytes32 role, address target) external;
 
     /// @notice Revokes a global role from a set of targets
     /// @param role The role to grant
     /// @param targets The addresses to grant the role to
-    /// @dev Only the addresses with the Owner role should be able to call this function
+    /// @dev Only the addresses with the Admin role should be able to call this function
     function revokeGlobalRoleBatched(bytes32 role, address[] calldata targets)
         external;
 
-    /// @notice Returns the role ID of the owner role
+    /// @notice Returns the role ID of the admin role
     /// @return The role ID
-    function getOwnerRole() external view returns (bytes32);
+    function getAdminRole() external view returns (bytes32);
 
     /// @notice Returns the role ID of the manager role
     /// @return The role ID

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -106,17 +106,7 @@ contract AUT_Roles_v1 is
         // It is defined in the AccessControl contract and identified with bytes32("0x00")
         // Modules can opt out of this on a per-role basis by setting the admin role to "BURN_ADMIN_ROLE".
 
-        // Set up OWNER role structure:
-
-        // -> set OWNER as admin of itself
-        //_setRoleAdmin(DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
-        // -> set OWNER as admin of DEFAULT_ADMIN_ROLE
-        //_setRoleAdmin(DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
-
-        // Set up MANAGER role structure:
-        // -> set OWNER as admin of DEFAULT_ADMIN_ROLE
-        _setRoleAdmin(ORCHESTRATOR_MANAGER_ROLE, DEFAULT_ADMIN_ROLE);
-        // grant MANAGER Role to specified address
+        // Grant MANAGER Role to specified address
         _grantRole(ORCHESTRATOR_MANAGER_ROLE, initialManager);
 
         // If there is no initial owner specfied or the initial owner is the same as the deployer

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -50,11 +50,7 @@ contract AUT_Roles_v1 is
 
     //--------------------------------------------------------------------------
     // Storage
-
-    // Stored for easy public reference. Other Modules can assume the following roles to exist
-    bytes32 public constant ORCHESTRATOR_OWNER_ROLE = "0x01";
     bytes32 public constant ORCHESTRATOR_MANAGER_ROLE = "0x02";
-
     bytes32 public constant BURN_ADMIN_ROLE =
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
 
@@ -72,8 +68,8 @@ contract AUT_Roles_v1 is
     /// @notice Verifies that the owner being removed is not the last one
     modifier notLastOwner(bytes32 role) {
         if (
-            role == ORCHESTRATOR_OWNER_ROLE
-                && getRoleMemberCount(ORCHESTRATOR_OWNER_ROLE) <= 1
+            role == DEFAULT_ADMIN_ROLE
+                && getRoleMemberCount(DEFAULT_ADMIN_ROLE) <= 1
         ) {
             revert Module__Authorizer__OwnerRoleCannotBeEmpty();
         }
@@ -106,29 +102,29 @@ contract AUT_Roles_v1 is
         internal
         onlyInitializing
     {
-        // Note about DEFAULT_ADMIN_ROLE: The DEFAULT_ADMIN_ROLE has admin privileges on all roles in the contract. It starts out empty, but we set the orchestrator owners as "admins of the admin role",
-        // so they can whitelist an address which then will have full write access to the roles in the system. This is mainly intended for safety/recovery situations,
+        // Note about DEFAULT_ADMIN_ROLE: The Owner of the workflow holds the DEFAULT_ADMIN_ROLE, and has admin privileges on all Modules in the contract.
+        // It is defined in the AccessControl contract and identified with bytes32("0x00")
         // Modules can opt out of this on a per-role basis by setting the admin role to "BURN_ADMIN_ROLE".
 
         // Set up OWNER role structure:
 
         // -> set OWNER as admin of itself
-        _setRoleAdmin(ORCHESTRATOR_OWNER_ROLE, ORCHESTRATOR_OWNER_ROLE);
+        //_setRoleAdmin(DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
         // -> set OWNER as admin of DEFAULT_ADMIN_ROLE
-        _setRoleAdmin(DEFAULT_ADMIN_ROLE, ORCHESTRATOR_OWNER_ROLE);
+        //_setRoleAdmin(DEFAULT_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
 
         // Set up MANAGER role structure:
         // -> set OWNER as admin of DEFAULT_ADMIN_ROLE
-        _setRoleAdmin(ORCHESTRATOR_MANAGER_ROLE, ORCHESTRATOR_OWNER_ROLE);
+        _setRoleAdmin(ORCHESTRATOR_MANAGER_ROLE, DEFAULT_ADMIN_ROLE);
         // grant MANAGER Role to specified address
         _grantRole(ORCHESTRATOR_MANAGER_ROLE, initialManager);
 
         // If there is no initial owner specfied or the initial owner is the same as the deployer
 
         if (initialOwner != address(0)) {
-            _grantRole(ORCHESTRATOR_OWNER_ROLE, initialOwner);
+            _grantRole(DEFAULT_ADMIN_ROLE, initialOwner);
         } else {
-            _grantRole(ORCHESTRATOR_OWNER_ROLE, _msgSender());
+            _grantRole(DEFAULT_ADMIN_ROLE, _msgSender());
         }
     }
 
@@ -234,7 +230,7 @@ contract AUT_Roles_v1 is
     /// @inheritdoc IAuthorizer_v1
     function grantGlobalRole(bytes32 role, address target)
         external
-        onlyRole(ORCHESTRATOR_OWNER_ROLE)
+        onlyRole(DEFAULT_ADMIN_ROLE)
     {
         bytes32 roleId = generateRoleId(address(orchestrator()), role);
         _grantRole(roleId, target);
@@ -243,7 +239,7 @@ contract AUT_Roles_v1 is
     /// @inheritdoc IAuthorizer_v1
     function grantGlobalRoleBatched(bytes32 role, address[] calldata targets)
         external
-        onlyRole(ORCHESTRATOR_OWNER_ROLE)
+        onlyRole(DEFAULT_ADMIN_ROLE)
     {
         bytes32 roleId = generateRoleId(address(orchestrator()), role);
         for (uint i = 0; i < targets.length; i++) {
@@ -254,7 +250,7 @@ contract AUT_Roles_v1 is
     /// @inheritdoc IAuthorizer_v1
     function revokeGlobalRole(bytes32 role, address target)
         external
-        onlyRole(ORCHESTRATOR_OWNER_ROLE)
+        onlyRole(DEFAULT_ADMIN_ROLE)
     {
         bytes32 roleId = generateRoleId(address(orchestrator()), role);
         _revokeRole(roleId, target);
@@ -263,7 +259,7 @@ contract AUT_Roles_v1 is
     /// @inheritdoc IAuthorizer_v1
     function revokeGlobalRoleBatched(bytes32 role, address[] calldata targets)
         external
-        onlyRole(ORCHESTRATOR_OWNER_ROLE)
+        onlyRole(DEFAULT_ADMIN_ROLE)
     {
         bytes32 roleId = generateRoleId(address(orchestrator()), role);
         for (uint i = 0; i < targets.length; i++) {
@@ -273,7 +269,7 @@ contract AUT_Roles_v1 is
 
     /// @inheritdoc IAuthorizer_v1
     function getOwnerRole() public pure returns (bytes32) {
-        return ORCHESTRATOR_OWNER_ROLE;
+        return DEFAULT_ADMIN_ROLE;
     }
 
     /// @inheritdoc IAuthorizer_v1

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -65,13 +65,13 @@ contract AUT_Roles_v1 is
         _;
     }
 
-    /// @notice Verifies that the owner being removed is not the last one
-    modifier notLastOwner(bytes32 role) {
+    /// @notice Verifies that the admin being removed is not the last one
+    modifier notLastAdmin(bytes32 role) {
         if (
             role == DEFAULT_ADMIN_ROLE
                 && getRoleMemberCount(DEFAULT_ADMIN_ROLE) <= 1
         ) {
-            revert Module__Authorizer__OwnerRoleCannotBeEmpty();
+            revert Module__Authorizer__AdminRoleCannotBeEmpty();
         }
         _;
     }
@@ -92,27 +92,27 @@ contract AUT_Roles_v1 is
     ) external override initializer {
         __Module_init(orchestrator_, metadata);
 
-        (address initialOwner, address initialManager) =
+        (address initialAdmin, address initialManager) =
             abi.decode(configData, (address, address));
 
-        __RoleAuthorizer_init(initialOwner, initialManager);
+        __RoleAuthorizer_init(initialAdmin, initialManager);
     }
 
-    function __RoleAuthorizer_init(address initialOwner, address initialManager)
+    function __RoleAuthorizer_init(address initialAdmin, address initialManager)
         internal
         onlyInitializing
     {
-        // Note about DEFAULT_ADMIN_ROLE: The Owner of the workflow holds the DEFAULT_ADMIN_ROLE, and has admin privileges on all Modules in the contract.
+        // Note about DEFAULT_ADMIN_ROLE: The Admin of the workflow holds the DEFAULT_ADMIN_ROLE, and has admin privileges on all Modules in the contract.
         // It is defined in the AccessControl contract and identified with bytes32("0x00")
         // Modules can opt out of this on a per-role basis by setting the admin role to "BURN_ADMIN_ROLE".
 
         // Grant MANAGER Role to specified address
         _grantRole(ORCHESTRATOR_MANAGER_ROLE, initialManager);
 
-        // If there is no initial owner specfied or the initial owner is the same as the deployer
+        // If there is no initial admin specfied or the initial admin is the same as the deployer
 
-        if (initialOwner != address(0)) {
-            _grantRole(DEFAULT_ADMIN_ROLE, initialOwner);
+        if (initialAdmin != address(0)) {
+            _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
         } else {
             _grantRole(DEFAULT_ADMIN_ROLE, _msgSender());
         }
@@ -121,7 +121,7 @@ contract AUT_Roles_v1 is
     //--------------------------------------------------------------------------
     // Overloaded and overriden functions
 
-    /// @notice Overrides {_revokeRole} to prevent having an empty OWNER role
+    /// @notice Overrides {_revokeRole} to prevent having an empty ADMIN role
     /// @param role The id number of the role
     /// @param who The user we want to check on
     /// @return bool Returns if revoke has been succesful
@@ -129,7 +129,7 @@ contract AUT_Roles_v1 is
         internal
         virtual
         override
-        notLastOwner(role)
+        notLastAdmin(role)
         returns (bool)
     {
         return super._revokeRole(role, who);
@@ -258,7 +258,7 @@ contract AUT_Roles_v1 is
     }
 
     /// @inheritdoc IAuthorizer_v1
-    function getOwnerRole() public pure returns (bytes32) {
+    function getAdminRole() public pure returns (bytes32) {
         return DEFAULT_ADMIN_ROLE;
     }
 

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -76,17 +76,17 @@ abstract contract Module_v1 is
 
     /// @notice Modifier to guarantee function is only callable by addresses
     ///         authorized via Orchestrator_v1.
-    modifier onlyOrchestratorOwner() {
+    modifier onlyOrchestratorAdmin() {
         _checkRoleModifier(
-            __Module_orchestrator.authorizer().getOwnerRole(), _msgSender()
+            __Module_orchestrator.authorizer().getAdminRole(), _msgSender()
         );
         _;
     }
 
     /// @notice Modifier to guarantee function is only callable by either
     ///         addresses authorized via Orchestrator_v1 or the Orchestrator_v1's manager.
-    modifier onlyOrchestratorOwnerOrManager() {
-        _checkOnlyOrchestratorOwnerOrManagerModifier();
+    modifier onlyOrchestratorAdminOrManager() {
+        _checkonlyOrchestratorAdminOrManagerModifier();
         _;
     }
 
@@ -289,19 +289,19 @@ abstract contract Module_v1 is
         }
     }
 
-    function _checkOnlyOrchestratorOwnerOrManagerModifier() internal view {
+    function _checkonlyOrchestratorAdminOrManagerModifier() internal view {
         IAuthorizer_v1 authorizer = __Module_orchestrator.authorizer();
 
-        bytes32 ownerRole = authorizer.getOwnerRole();
+        bytes32 adminRole = authorizer.getAdminRole();
         bytes32 managerRole = authorizer.getManagerRole();
 
         if (
-            authorizer.hasRole(ownerRole, _msgSender())
+            authorizer.hasRole(adminRole, _msgSender())
                 || authorizer.hasRole(managerRole, _msgSender())
         ) {
             return;
         } else {
-            revert Module__CallerNotAuthorized(ownerRole, _msgSender());
+            revert Module__CallerNotAuthorized(adminRole, _msgSender());
         }
     }
 

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -101,6 +101,17 @@ abstract contract Module_v1 is
         _;
     }
 
+    modifier onlyModuleRoleAdmin(bytes32 role) {
+        bytes32 moduleRole = __Module_orchestrator.authorizer().generateRoleId(
+            address(this), role
+        );
+        _checkRoleModifier(
+            __Module_orchestrator.authorizer().getRoleAdmin(moduleRole),
+            _msgSender()
+        );
+        _;
+    }
+
     /// @notice Modifier to guarantee function is only callable by the orchestrator.
     /// @dev onlyOrchestrator functions MUST only access the module's storage, i.e.
     ///      `__Module_` variables.
@@ -186,14 +197,14 @@ abstract contract Module_v1 is
 
     function grantModuleRole(bytes32 role, address target)
         external
-        onlyOrchestratorOwner
+        onlyModuleRoleAdmin(role)
     {
         __Module_orchestrator.authorizer().grantRoleFromModule(role, target);
     }
 
     function grantModuleRoleBatched(bytes32 role, address[] calldata targets)
         external
-        onlyOrchestratorOwner
+        onlyModuleRoleAdmin(role)
     {
         __Module_orchestrator.authorizer().grantRoleFromModuleBatched(
             role, targets
@@ -202,14 +213,14 @@ abstract contract Module_v1 is
 
     function revokeModuleRole(bytes32 role, address target)
         external
-        onlyOrchestratorOwner
+        onlyModuleRoleAdmin(role)
     {
         __Module_orchestrator.authorizer().revokeRoleFromModule(role, target);
     }
 
     function revokeModuleRoleBatched(bytes32 role, address[] calldata targets)
         external
-        onlyOrchestratorOwner
+        onlyModuleRoleAdmin(role)
     {
         __Module_orchestrator.authorizer().revokeRoleFromModuleBatched(
             role, targets

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -48,7 +48,7 @@ import {SafeERC20} from "@oz/token/ERC20/utils/SafeERC20.sol";
  *
  * @dev     Inherits {BondingCurveBase_v1}, {RedeemingBondingCurveBase_v1}, {VirtualIssuanceSupplyBase_v1},
  *          and {VirtualCollateralSupplyBase_v1}. Implements formulaWrapper functions for bonding curve
- *          calculations using the Bancor formula. {Orchestrator_v1} Owner or Manager manages
+ *          calculations using the Bancor formula. {Orchestrator_v1} Admin manages
  *          configuration such as virtual supplies and reserve ratios. Ensure interaction adheres to
  *          defined transactional limits and decimal precision requirements to prevent computational
  *          overflows or underflows.
@@ -329,7 +329,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
     function mintIssuanceTokenTo(address _receiver, uint _amount)
         external
         virtual
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
         validReceiver(_receiver)
     {
         _mint(_receiver, _amount);
@@ -340,7 +340,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
         external
         virtual
         override(VirtualIssuanceSupplyBase_v1)
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _setVirtualIssuanceSupply(_virtualSupply);
     }
@@ -350,7 +350,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
         external
         virtual
         override(VirtualCollateralSupplyBase_v1)
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _setVirtualCollateralSupply(_virtualSupply);
     }
@@ -359,7 +359,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
     function setReserveRatioForBuying(uint32 _reserveRatio)
         external
         virtual
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _setReserveRatioForBuying(_reserveRatio);
     }
@@ -368,7 +368,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
     function setReserveRatioForSelling(uint32 _reserveRatio)
         external
         virtual
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _setReserveRatioForSelling(_reserveRatio);
     }

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -74,7 +74,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1 is
         external
         view
         override(FM_BC_Bancor_Redeeming_VirtualSupply_v1)
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         revert
             Module__FM_BC_Restricted_Bancor_Redeeming_VirtualSupply__FeatureDeactivated(

--- a/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/BondingCurveBase_v1.sol
@@ -99,19 +99,19 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     // OnlyOrchestrator Functions
 
     /// @inheritdoc IBondingCurveBase_v1
-    function openBuy() external virtual onlyOrchestratorOwner {
+    function openBuy() external virtual onlyOrchestratorAdmin {
         buyIsOpen = true;
         emit BuyingEnabled();
     }
 
     /// @inheritdoc IBondingCurveBase_v1
-    function closeBuy() external virtual onlyOrchestratorOwner {
+    function closeBuy() external virtual onlyOrchestratorAdmin {
         buyIsOpen = false;
         emit BuyingDisabled();
     }
 
     /// @inheritdoc IBondingCurveBase_v1
-    function setBuyFee(uint _fee) external virtual onlyOrchestratorOwner {
+    function setBuyFee(uint _fee) external virtual onlyOrchestratorAdmin {
         _setBuyFee(_fee);
     }
 
@@ -157,7 +157,7 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
         public
         virtual
         validReceiver(_receiver)
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         if (_amount > projectCollateralFeeCollected) {
             revert Module__BondingCurveBase__InvalidWithdrawAmount();
@@ -407,10 +407,10 @@ abstract contract BondingCurveBase_v1 is IBondingCurveBase_v1, Module_v1 {
     function _mint(address _to, uint _amount) internal virtual {
         issuanceToken.mint(_to, _amount);
     }
+
     /// @dev Burns tokens
     /// @param _from The address of the owner.
     /// @param _amount The amount of tokens to burn.
-
     function _burn(address _from, uint _amount) internal virtual {
         issuanceToken.burn(_from, _amount);
     }

--- a/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/RedeemingBondingCurveBase_v1.sol
@@ -84,19 +84,19 @@ abstract contract RedeemingBondingCurveBase_v1 is
     // OnlyOrchestrator Functions
 
     /// @inheritdoc IRedeemingBondingCurveBase_v1
-    function openSell() external virtual onlyOrchestratorOwner {
+    function openSell() external virtual onlyOrchestratorAdmin {
         sellIsOpen = true;
         emit SellingEnabled();
     }
 
     /// @inheritdoc IRedeemingBondingCurveBase_v1
-    function closeSell() external virtual onlyOrchestratorOwner {
+    function closeSell() external virtual onlyOrchestratorAdmin {
         sellIsOpen = false;
         emit SellingDisabled();
     }
 
     /// @inheritdoc IRedeemingBondingCurveBase_v1
-    function setSellFee(uint _fee) external virtual onlyOrchestratorOwner {
+    function setSellFee(uint _fee) external virtual onlyOrchestratorAdmin {
         _setSellFee(_fee);
     }
 

--- a/src/modules/fundingManager/bondingCurve/interfaces/IBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/interfaces/IBondingCurveBase_v1.sol
@@ -109,17 +109,17 @@ interface IBondingCurveBase_v1 {
     function buy(uint _depositAmount, uint _minAmountOut) external;
 
     /// @notice Opens the buying functionality for the token.
-    /// @dev Only callable by the Orchestrator_v1 owner, or Manager.
+    /// @dev Only callable by the Orchestrator_v1 admin.
     ///      Reverts if buying is already open.
     function openBuy() external;
 
     /// @notice Closes the buying functionality for the token.
-    /// @dev Only callable by the Orchestrator_v1 owner, or Manager.
+    /// @dev Only callable by the Orchestrator_v1 admin.
     ///      Reverts if buying is already closed.
     function closeBuy() external;
 
     /// @notice Sets the fee percentage for buying tokens, payed in collateral
-    /// @dev Only callable by the Orchestrator_v1 owner, or Manager.
+    /// @dev Only callable by the Orchestrator_v1 admin.
     ///      The fee cannot exceed 10000 basis points. Reverts if an invalid fee is provided.
     /// @param _fee The fee in basis points.
     function setBuyFee(uint _fee) external;

--- a/src/modules/fundingManager/bondingCurve/interfaces/IFM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/interfaces/IFM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -52,19 +52,19 @@ interface IFM_BC_Bancor_Redeeming_VirtualSupply_v1 {
     // Functions
 
     /// @notice Mints a specified amount of Issuance Tokens to a designated receiver address.
-    /// @dev This function is restricted to be called only by the Orchestrator_v1 Owner.
+    /// @dev This function is restricted to be called only by the Orchestrator_v1 Admin.
     ///      It uses the internal _mint function to mint the tokens.
     /// @param _receiver The address that will receive the newly minted tokens.
     /// @param _amount The amount of tokens to be minted.
     function mintIssuanceTokenTo(address _receiver, uint _amount) external;
 
     /// @notice Set the reserve ratio used for issuing tokens on a bonding curve.
-    /// @dev This function can only be called by the Orchestrator_v1 owner, or Manager.
+    /// @dev This function can only be called by the Orchestrator_v1 admin
     /// @param _reserveRatio The new reserve ratio for buying, expressed in PPM.
     function setReserveRatioForBuying(uint32 _reserveRatio) external;
 
     /// @notice Set the reserve ratio used for redeeming tokens on a bonding curve.
-    /// @dev This function can only be called by the Orchestrator_v1 owner, or Manager.
+    /// @dev This function can only be called by the Orchestrator_v1 admin
     /// @param _reserveRatio The new reserve ratio for selling, expressed in PPM.
     function setReserveRatioForSelling(uint32 _reserveRatio) external;
 

--- a/src/modules/fundingManager/bondingCurve/interfaces/IRedeemingBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/interfaces/IRedeemingBondingCurveBase_v1.sol
@@ -56,17 +56,17 @@ interface IRedeemingBondingCurveBase_v1 {
     function sell(uint _depositAmount, uint _minAmountOut) external;
 
     /// @notice Opens the selling functionality for the collateral.
-    /// @dev Only callable by the Orchestrator_v1 owner, or Manager.
+    /// @dev Only callable by the Orchestrator_v1 admin.
     ///      Reverts if selling is already open.
     function openSell() external;
 
     /// @notice Closes the selling functionality for the collateral.
-    /// @dev Only callable by the Orchestrator_v1 owner, or Manager.
+    /// @dev Only callable by the Orchestrator_v1 admin.
     ///      Reverts if selling is already closed.
     function closeSell() external;
 
     /// @notice Sets the fee percentage for selling collateral, payed in collateral
-    /// @dev Only callable by the Orchestrator_v1 owner, or Manager.
+    /// @dev Only callable by the Orchestrator_v1 admin.
     ///      The fee cannot exceed 10000 basis points. Reverts if an invalid fee is provided.
     /// @param _fee The fee in basis points.
     function setSellFee(uint _fee) external;

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -52,7 +52,7 @@ contract LM_PC_KPIRewarder_v1 is
     // This module enable KPI based reward distribution into the staking manager by using UMAs Optimistic Oracle.
 
     // It works in the following way:
-    // - The owner can create KPIs, which are a set of tranches with rewards assigned. These can be continuous or not (see below)
+    // - The admin can create KPIs, which are a set of tranches with rewards assigned. These can be continuous or not (see below)
     // - An external actor with the ASSERTER role can trigger the posting of an assertion to the UMA Oracle, specifying the value to be asserted and the KPI to use for the reward distrbution in case it resolves
     // - To ensure fairness, all new staking requests are queued until the next KPI assertion is resolved. They will be added before posting the next assertion.
     // - Once the assertion resolves, the UMA oracle triggers the assertionResolvedCallback() function. This will calculate the final reward value and distribute it to the stakers.
@@ -188,13 +188,13 @@ contract LM_PC_KPIRewarder_v1 is
     }
 
     // ========================================================================
-    // Owner Configuration Functions:
+    // Admin Configuration Functions:
 
     // Top up funds to pay the optimistic oracle fee
     /// @inheritdoc ILM_PC_KPIRewarder_v1
     function depositFeeFunds(uint amount)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
         nonReentrant
         validAmount(amount)
     {
@@ -208,7 +208,7 @@ contract LM_PC_KPIRewarder_v1 is
         bool _continuous,
         uint[] calldata _trancheValues,
         uint[] calldata _trancheRewards
-    ) external onlyOrchestratorOwner returns (uint) {
+    ) external onlyOrchestratorAdmin returns (uint) {
         uint _numOfTranches = _trancheValues.length;
 
         if (_numOfTranches < 1 || _numOfTranches > 20) {

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -188,7 +188,7 @@ contract LM_PC_RecurringPayments_v1 is
         address recipient
     )
         external
-        onlyOrchestratorOwnerOrManager
+        onlyOrchestratorAdminOrManager
         validAmount(amount)
         validStartEpoch(startEpoch)
         validRecipient(recipient)
@@ -220,7 +220,7 @@ contract LM_PC_RecurringPayments_v1 is
     /// @inheritdoc ILM_PC_RecurringPayments_v1
     function removeRecurringPayment(uint prevId, uint id)
         external
-        onlyOrchestratorOwnerOrManager
+        onlyOrchestratorAdminOrManager
     {
         //trigger to resolve the given Payment
         _triggerFor(id, _paymentList.getNextId(id));

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -194,7 +194,7 @@ contract LM_PC_Staking_v1 is
     /// @inheritdoc ILM_PC_Staking_v1
     function setRewards(uint amount, uint duration)
         external
-        onlyOrchestratorOwnerOrManager
+        onlyOrchestratorAdminOrManager
     {
         _setRewards(amount, duration);
     }

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -97,20 +97,20 @@ abstract contract OptimisticOracleIntegrator is
     /// @inheritdoc IOptimisticOracleIntegrator
     function setDefaultCurrency(address _newCurrency)
         public
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _setDefaultCurrency(_newCurrency);
     }
 
     /// @inheritdoc IOptimisticOracleIntegrator
-    function setOptimisticOracle(address _newOO) public onlyOrchestratorOwner {
+    function setOptimisticOracle(address _newOO) public onlyOrchestratorAdmin {
         _setOptimisticOracle(_newOO);
     }
 
     /// @inheritdoc IOptimisticOracleIntegrator
     function setDefaultAssertionLiveness(uint64 _newLiveness)
         public
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _setDefaultAssertionLiveness(_newLiveness);
     }

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -243,7 +243,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     function removeAllPaymentReceiverPayments(
         address client,
         address paymentReceiver
-    ) external onlyOrchestratorOwner {
+    ) external onlyOrchestratorAdmin {
         if (
             _findAddressInActiveStreams(client, paymentReceiver)
                 == type(uint).max
@@ -260,7 +260,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
         address client,
         address paymentReceiver,
         uint streamId
-    ) external onlyOrchestratorOwner {
+    ) external onlyOrchestratorAdmin {
         // First, we give the streamed funds from this specific streamId to the beneficiary
         _claimForSpecificStream(client, paymentReceiver, streamId);
 

--- a/src/orchestrator/Orchestrator_v1.sol
+++ b/src/orchestrator/Orchestrator_v1.sol
@@ -58,13 +58,13 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     //--------------------------------------------------------------------------
     // Modifiers
 
-    /// @notice Modifier to guarantee function is only callable by the owner of the workflow
+    /// @notice Modifier to guarantee function is only callable by the admin of the workflow
     ///         address.
-    modifier onlyOrchestratorOwner() {
-        bytes32 ownerRole = authorizer.getOwnerRole();
+    modifier onlyOrchestratorAdmin() {
+        bytes32 adminRole = authorizer.getAdminRole();
 
-        if (!authorizer.hasRole(ownerRole, _msgSender())) {
-            revert Orchestrator__CallerNotAuthorized(ownerRole, _msgSender());
+        if (!authorizer.hasRole(adminRole, _msgSender())) {
+            revert Orchestrator__CallerNotAuthorized(adminRole, _msgSender());
         }
         _;
     }
@@ -200,16 +200,16 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
         override(ModuleManagerBase_v1)
         returns (bool)
     {
-        return authorizer.hasRole(authorizer.getOwnerRole(), who);
+        return authorizer.hasRole(authorizer.getAdminRole(), who);
     }
 
     //--------------------------------------------------------------------------
-    // onlyOrchestratorOwner Functions
+    // onlyOrchestratorAdmin Functions
 
     /// @inheritdoc IOrchestrator_v1
     function initiateSetAuthorizerWithTimelock(IAuthorizer_v1 authorizer_)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         address authorizerContract = address(authorizer_);
         bytes4 moduleInterfaceId = type(IModule_v1).interfaceId;
@@ -232,7 +232,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function executeSetAuthorizer(IAuthorizer_v1 authorizer_)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _executeAddModule(address(authorizer_));
         _executeRemoveModule(address(authorizer));
@@ -243,7 +243,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function cancelAuthorizerUpdate(IAuthorizer_v1 authorizer_)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _cancelModuleUpdate(address(authorizer_));
     }
@@ -251,7 +251,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function initiateSetFundingManagerWithTimelock(
         IFundingManager_v1 fundingManager_
-    ) external onlyOrchestratorOwner {
+    ) external onlyOrchestratorAdmin {
         address fundingManagerContract = address(fundingManager_);
         bytes4 moduleInterfaceId = type(IModule_v1).interfaceId;
         bytes4 fundingManagerInterfaceId = type(IFundingManager_v1).interfaceId;
@@ -273,7 +273,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function executeSetFundingManager(IFundingManager_v1 fundingManager_)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _executeAddModule(address(fundingManager_));
         _executeRemoveModule(address(fundingManager));
@@ -284,7 +284,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function cancelFundingManagerUpdate(IFundingManager_v1 fundingManager_)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _cancelModuleUpdate(address(fundingManager_));
     }
@@ -292,7 +292,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function initiateSetPaymentProcessorWithTimelock(
         IPaymentProcessor_v1 paymentProcessor_
-    ) external onlyOrchestratorOwner {
+    ) external onlyOrchestratorAdmin {
         address paymentProcessorContract = address(paymentProcessor_);
         bytes4 moduleInterfaceId = type(IModule_v1).interfaceId;
         bytes4 paymentProcessorInterfaceId =
@@ -315,7 +315,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function executeSetPaymentProcessor(IPaymentProcessor_v1 paymentProcessor_)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
     {
         _executeAddModule(address(paymentProcessor_));
         _executeRemoveModule(address(paymentProcessor));
@@ -326,7 +326,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function cancelPaymentProcessorUpdate(
         IPaymentProcessor_v1 paymentProcessor_
-    ) external onlyOrchestratorOwner {
+    ) external onlyOrchestratorAdmin {
         _cancelModuleUpdate(address(paymentProcessor_));
     }
 
@@ -370,7 +370,7 @@ contract Orchestrator_v1 is IOrchestrator_v1, ModuleManagerBase_v1 {
     /// @inheritdoc IOrchestrator_v1
     function executeTx(address target, bytes memory data)
         external
-        onlyOrchestratorOwner
+        onlyOrchestratorAdmin
         returns (bytes memory)
     {
         bool ok;

--- a/src/orchestrator/abstracts/ModuleManagerBase_v1.sol
+++ b/src/orchestrator/abstracts/ModuleManagerBase_v1.sol
@@ -211,7 +211,7 @@ abstract contract ModuleManagerBase_v1 is
     }
 
     //--------------------------------------------------------------------------
-    // onlyOrchestratorOwner Functions
+    // onlyOrchestratorAdmin Functions
 
     function _cancelModuleUpdate(address module)
         internal

--- a/test/e2e/authorizer/RoleAuthorizerE2E.t.sol
+++ b/test/e2e/authorizer/RoleAuthorizerE2E.t.sol
@@ -26,7 +26,7 @@ contract RoleAuthorizerE2E is E2ETest {
     IOrchestratorFactory_v1.ModuleConfig[] moduleConfigurations;
 
     // E2E Test Variables
-    address orchestratorOwner = makeAddr("orchestratorOwner");
+    address orchestratorAdmin = makeAddr("orchestratorAdmin");
     address orchestratorManager = makeAddr("orchestratorManager");
     address bountySubmitter = makeAddr("bountySubmitter");
 
@@ -112,9 +112,9 @@ contract RoleAuthorizerE2E is E2ETest {
         // Assign Bounty Manager Roles
         //--------------------------------------------------------------------------------
 
-        // we authorize the owner to create  bounties
+        // we authorize the Admin to create  bounties
         bountyManager.grantModuleRole(
-            bountyManager.BOUNTY_ISSUER_ROLE(), address(orchestratorOwner)
+            bountyManager.BOUNTY_ISSUER_ROLE(), address(orchestratorAdmin)
         );
 
         // we authorize the manager to verify bounty claims
@@ -127,7 +127,7 @@ contract RoleAuthorizerE2E is E2ETest {
             bountyManager.CLAIMANT_ROLE(), address(bountySubmitter)
         );
 
-        // Since we deploy the orchestrator, with address(this) as owner and manager for easier setup,
+        // Since we deploy the orchestrator, with address(this) as admin and manager for easier setup,
         // we now assign them to two external addresses. In production these will be directly set on deployment.
 
         // we grant manager role to managerAddress
@@ -137,12 +137,12 @@ contract RoleAuthorizerE2E is E2ETest {
         assertTrue(authorizer.hasRole(managerRole, orchestratorManager));
         assertEq(authorizer.getRoleMemberCount(managerRole), 1);
 
-        //we grant owner role to ownerAddress
-        bytes32 ownerRole = authorizer.getOwnerRole();
-        authorizer.grantRole(ownerRole, address(orchestratorOwner));
-        authorizer.renounceRole(ownerRole, address(this));
-        assertTrue(authorizer.hasRole(ownerRole, orchestratorOwner));
-        assertEq(authorizer.getRoleMemberCount(ownerRole), 1);
+        //we grant admin role to adminAddress
+        bytes32 adminRole = authorizer.getAdminRole();
+        authorizer.grantRole(adminRole, address(orchestratorAdmin));
+        authorizer.renounceRole(adminRole, address(this));
+        assertTrue(authorizer.hasRole(adminRole, orchestratorAdmin));
+        assertEq(authorizer.getRoleMemberCount(adminRole), 1);
 
         //--------------------------------------------------------------------------------
         // Set up seed deposit and initial deposit by users
@@ -172,7 +172,7 @@ contract RoleAuthorizerE2E is E2ETest {
         uint maximumPayoutAmount = 500e18;
         bytes memory details = "This is a test bounty";
 
-        vm.prank(orchestratorOwner);
+        vm.prank(orchestratorAdmin);
         uint bountyId = bountyManager.addBounty(
             minimumPayoutAmount, maximumPayoutAmount, details
         );

--- a/test/e2e/authorizer/TokenGatedRoleAuthorizerE2E.t.sol
+++ b/test/e2e/authorizer/TokenGatedRoleAuthorizerE2E.t.sol
@@ -23,7 +23,7 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
     IOrchestratorFactory_v1.ModuleConfig[] moduleConfigurations;
 
     // E2E Test Variables
-    address orchestratorOwner = makeAddr("orchestratorOwner");
+    address orchestratorAdmin = makeAddr("orchestratorAdmin");
     address orchestratorManager = makeAddr("orchestratorManager");
     address bountySubmitter = makeAddr("bountySubmitter");
 
@@ -112,10 +112,10 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
         // Set up Bounty Manager Roles with different thresholds
         //--------------------------------------------------------------------------------
 
-        //Give the Orchestrator_v1 owner the power to change module roles
-        authorizer.grantRole(authorizer.DEFAULT_ADMIN_ROLE(), orchestratorOwner);
+        //Give the Orchestrator_v1 Admin the power to change module roles
+        authorizer.grantRole(authorizer.DEFAULT_ADMIN_ROLE(), orchestratorAdmin);
 
-        vm.startPrank(orchestratorOwner);
+        vm.startPrank(orchestratorAdmin);
         {
             // Make the BOUNTY_ADMIN_ROLE token-gated by GATOR token and set the threshold
             bytes32 bountyRoleId = authorizer.generateRoleId(
@@ -125,8 +125,8 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
             authorizer.grantRole(bountyRoleId, address(gatingToken));
             authorizer.setThreshold(bountyRoleId, address(gatingToken), 100);
 
-            // We mint 101 tokens to the orchestrator owner so they can create bounties
-            gatingToken.mint(orchestratorOwner, 101);
+            // We mint 101 tokens to the orchestrator admin so they can create bounties
+            gatingToken.mint(orchestratorAdmin, 101);
 
             // Make the VERIFY_ADMIN_ROLE token-gated by GATOR token and set the threshold
             bytes32 verifierRoleId = authorizer.generateRoleId(
@@ -175,7 +175,7 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
         //--------------------------------------------------------------------------------
         // Create bounty
         //--------------------------------------------------------------------------------
-        vm.prank(orchestratorOwner);
+        vm.prank(orchestratorAdmin);
         uint bountyId =
             bountyManager.addBounty(100e18, 500e18, "This is a test bounty");
 

--- a/test/e2e/authorizer/extensions/VotingRoleManagerE2E.t.sol
+++ b/test/e2e/authorizer/extensions/VotingRoleManagerE2E.t.sol
@@ -126,17 +126,17 @@ contract VotingRoleManagerE2E is E2ETest {
             }
         }
 
-        // We make the governor the only owner
-        bytes32 ownerRole = authorizer.getOwnerRole();
-        authorizer.grantRole(ownerRole, address(singleVoteGovernor));
+        // We make the governor the only admin
+        bytes32 adminRole = authorizer.getAdminRole();
+        authorizer.grantRole(adminRole, address(singleVoteGovernor));
 
         // we authorize governance to create  bounties
         bountyManager.grantModuleRole(
             bountyManager.BOUNTY_ISSUER_ROLE(), address(singleVoteGovernor)
         );
 
-        // By having address(this) renounce the Owner Role, all changes from now on need to go through the AUT_EXT_VotingRoles_v1
-        authorizer.renounceRole(ownerRole, address(this));
+        // By having address(this) renounce the Admin Role, all changes from now on need to go through the AUT_EXT_VotingRoles_v1
+        authorizer.renounceRole(adminRole, address(this));
 
         //--------------------------------------------------------------------------------
         // Set up Vote to create Bounty

--- a/test/external/ERC20Issuance.t.sol
+++ b/test/external/ERC20Issuance.t.sol
@@ -27,13 +27,13 @@ contract ERC20IssuanceTest is Test {
 
     /*
     test setMinter
-    ├── When the caller is not the Owner
+    ├── When the caller is not the Admin
     │   └── It should revert
-    └── When the caller is the Owner
+    └── When the caller is the Admin
     └── It should set the new minter address
     */
 
-    function testSetMinterFails_IfCallerNotOwner() public {
+    function testSetMinterFails_IfCallerNotAdmin() public {
         vm.startPrank(address(0xB0B));
         {
             vm.expectRevert(

--- a/test/modules/authorizer/extensions/AUT_EXT_VotingRoles_v1.t.sol
+++ b/test/modules/authorizer/extensions/AUT_EXT_VotingRoles_v1.t.sol
@@ -95,8 +95,8 @@ contract AUT_EXT_VotingRoles_v1Test is ModuleTest {
         _setUpOrchestrator(_governor);
 
         //we give the governor the ownwer role
-        bytes32 ownerRole = _authorizer.getOwnerRole();
-        _authorizer.grantRole(ownerRole, address(_governor));
+        bytes32 adminRole = _authorizer.getAdminRole();
+        _authorizer.grantRole(adminRole, address(_governor));
         //_authorizer.setIsAuthorized(address(_governor), true);
 
         // Initialize the governor with 3 users
@@ -273,14 +273,14 @@ contract AUT_EXT_VotingRoles_v1Test is ModuleTest {
     function testInit() public override(ModuleTest) {
         assertEq(_orchestrator.isModule(address(_governor)), true);
 
-        bytes32 owner = _authorizer.getOwnerRole();
+        bytes32 admin = _authorizer.getAdminRole();
 
-        assertEq(_authorizer.hasRole(owner, address(_governor)), true); // Owner role
+        assertEq(_authorizer.hasRole(admin, address(_governor)), true); // Admin role
         assertEq(_governor.isVoter(ALBA), true);
         assertEq(_governor.isVoter(BOB), true);
         assertEq(_governor.isVoter(COBIE), true);
-        assertEq(_authorizer.hasRole(owner, address(this)), true);
-        assertEq(_authorizer.hasRole(owner, address(_orchestrator)), false);
+        assertEq(_authorizer.hasRole(admin, address(this)), true);
+        assertEq(_authorizer.hasRole(admin, address(_orchestrator)), false);
         assertEq(_governor.isVoter(address(this)), false);
         assertEq(_governor.isVoter(address(_orchestrator)), false);
 
@@ -981,7 +981,7 @@ contract AUT_EXT_VotingRoles_v1Test is ModuleTest {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IOrchestrator_v1.Orchestrator__CallerNotAuthorized.selector,
-                _authorizer.getOwnerRole(),
+                _authorizer.getAdminRole(),
                 _other
             )
         );

--- a/test/modules/authorizer/role/AUT_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_Roles_v1.t.sol
@@ -134,11 +134,11 @@ contract AUT_RolesV1Test is Test {
             _authorizer.hasRole(_authorizer.getManagerRole(), address(this)),
             true
         );
-        //console.log(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA));
-        assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
-        //console.log(_authorizer.hasRole(_authorizer.getOwnerRole(), address(this)));
+        //console.log(_authorizer.hasRole(_authorizer.getAdminRole(), ALBA));
+        assertEq(_authorizer.hasRole(_authorizer.getAdminRole(), ALBA), true);
+        //console.log(_authorizer.hasRole(_authorizer.getAdminRole(), address(this)));
         assertEq(
-            _authorizer.hasRole(_authorizer.getOwnerRole(), address(this)),
+            _authorizer.hasRole(_authorizer.getAdminRole(), address(this)),
             false
         );
     }
@@ -152,7 +152,7 @@ contract AUT_RolesV1Test is Test {
         );
     }
 
-    function testInitWithInitialOwner(address initialAuth) public {
+    function testInitWithInitialAdmin(address initialAuth) public {
         //Checks that address list gets correctly stored on initialization
         // We "reuse" the orchestrator created in the setup, but the orchestrator doesn't know about this new authorizer.
 
@@ -171,21 +171,21 @@ contract AUT_RolesV1Test is Test {
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
         assertEq(
-            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), initialAuth),
+            testAuthorizer.hasRole(testAuthorizer.getAdminRole(), initialAuth),
             true
         );
 
         assertEq(
-            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), address(this)),
+            testAuthorizer.hasRole(testAuthorizer.getAdminRole(), address(this)),
             false
         );
         assertEq(
-            testAuthorizer.getRoleMemberCount(testAuthorizer.getOwnerRole()), 1
+            testAuthorizer.getRoleMemberCount(testAuthorizer.getAdminRole()), 1
         );
     }
 
-    function testInitWithoutInitialOwners() public {
-        //Checks that address list gets correctly stored on initialization if there are no owners given
+    function testInitWithoutInitialAdmins() public {
+        //Checks that address list gets correctly stored on initialization if there are no admins given
         // We "reuse" the orchestrator created in the setup, but the orchestrator doesn't know about this new authorizer.
 
         address authImpl = address(new AUT_Roles_v1());
@@ -202,15 +202,15 @@ contract AUT_RolesV1Test is Test {
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
         assertEq(
-            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), address(this)),
+            testAuthorizer.hasRole(testAuthorizer.getAdminRole(), address(this)),
             true
         );
         assertEq(
-            testAuthorizer.getRoleMemberCount(testAuthorizer.getOwnerRole()), 1
+            testAuthorizer.getRoleMemberCount(testAuthorizer.getAdminRole()), 1
         );
     }
 
-    function testInitWithInitialOwnerSameAsDeployer() public {
+    function testInitWithInitialAdminSameAsDeployer() public {
         //Checks that address list gets correctly stored on initialization
         // We "reuse" the orchestrator created in the setup, but the orchestrator doesn't know about this new authorizer.
 
@@ -228,12 +228,12 @@ contract AUT_RolesV1Test is Test {
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
         assertEq(
-            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), initialAuth),
+            testAuthorizer.hasRole(testAuthorizer.getAdminRole(), initialAuth),
             true
         );
 
         assertEq(
-            testAuthorizer.getRoleMemberCount(testAuthorizer.getOwnerRole()), 1
+            testAuthorizer.getRoleMemberCount(testAuthorizer.getAdminRole()), 1
         );
     }
 
@@ -243,32 +243,32 @@ contract AUT_RolesV1Test is Test {
             Clones.clone(address(new Orchestrator_v1(address(0))))
         );
 
-        address initialOwner = address(this);
+        address initialAdmin = address(this);
         address initialManager = address(this);
 
         vm.expectRevert();
         _authorizer.init(
             IOrchestrator_v1(newOrchestrator),
             _METADATA,
-            abi.encode(initialOwner, initialManager)
+            abi.encode(initialAdmin, initialManager)
         );
         assertEq(
-            _authorizer.hasRole(_authorizer.getOwnerRole(), address(this)),
+            _authorizer.hasRole(_authorizer.getAdminRole(), address(this)),
             false
         );
         assertEq(address(_authorizer.orchestrator()), address(_orchestrator));
-        assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
-        assertEq(_authorizer.getRoleMemberCount(_authorizer.getOwnerRole()), 1);
+        assertEq(_authorizer.hasRole(_authorizer.getAdminRole(), ALBA), true);
+        assertEq(_authorizer.getRoleMemberCount(_authorizer.getAdminRole()), 1);
     }
 
     // Test Register Roles
 
     //--------------------------------------------------------------------------------------
-    // Test manually granting and revoking roles as orchestrator-defined Owner
+    // Test manually granting and revoking roles as orchestrator-defined Admin
 
-    function testGrantOwnerRole(address[] memory newAuthorized) public {
+    function testGrantAdminRole(address[] memory newAuthorized) public {
         uint amountAuth =
-            _authorizer.getRoleMemberCount(_authorizer.getOwnerRole());
+            _authorizer.getRoleMemberCount(_authorizer.getAdminRole());
 
         _validateAuthorizedList(newAuthorized);
 
@@ -276,72 +276,72 @@ contract AUT_RolesV1Test is Test {
         for (uint i; i < newAuthorized.length; ++i) {
             vm.expectEmit(true, true, true, true);
             emit RoleGranted(
-                _authorizer.getOwnerRole(), newAuthorized[i], address(ALBA)
+                _authorizer.getAdminRole(), newAuthorized[i], address(ALBA)
             );
 
-            _authorizer.grantRole(_authorizer.getOwnerRole(), newAuthorized[i]);
+            _authorizer.grantRole(_authorizer.getAdminRole(), newAuthorized[i]);
         }
         vm.stopPrank();
 
         for (uint i; i < newAuthorized.length; ++i) {
             assertEq(
                 _authorizer.hasRole(
-                    _authorizer.getOwnerRole(), newAuthorized[i]
+                    _authorizer.getAdminRole(), newAuthorized[i]
                 ),
                 true
             );
         }
         assertEq(
-            _authorizer.getRoleMemberCount(_authorizer.getOwnerRole()),
+            _authorizer.getRoleMemberCount(_authorizer.getAdminRole()),
             (amountAuth + newAuthorized.length)
         );
     }
 
-    function testRevokeOwnerRole() public {
-        //Add Bob as owner
+    function testRevokeAdminRole() public {
+        //Add Bob as admin
         vm.startPrank(address(ALBA));
-        _authorizer.grantRole(_authorizer.getOwnerRole(), BOB); //Meet your new Manager
+        _authorizer.grantRole(_authorizer.getAdminRole(), BOB); //Meet your new Manager
         vm.stopPrank();
-        assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), BOB), true);
+        assertEq(_authorizer.hasRole(_authorizer.getAdminRole(), BOB), true);
 
         uint amountAuth =
-            _authorizer.getRoleMemberCount(_authorizer.getOwnerRole());
+            _authorizer.getRoleMemberCount(_authorizer.getAdminRole());
 
         vm.startPrank(address(ALBA));
 
         vm.expectEmit(true, true, true, true);
         emit RoleRevoked(
-            _authorizer.getOwnerRole(), address(ALBA), address(ALBA)
+            _authorizer.getAdminRole(), address(ALBA), address(ALBA)
         );
 
-        _authorizer.revokeRole(_authorizer.getOwnerRole(), ALBA);
+        _authorizer.revokeRole(_authorizer.getAdminRole(), ALBA);
         vm.stopPrank();
 
-        assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), false);
+        assertEq(_authorizer.hasRole(_authorizer.getAdminRole(), ALBA), false);
         assertEq(
-            _authorizer.getRoleMemberCount(_authorizer.getOwnerRole()),
+            _authorizer.getRoleMemberCount(_authorizer.getAdminRole()),
             amountAuth - 1
         );
     }
 
-    function testRemoveLastOwnerFails() public {
+    function testRemoveLastAdminFails() public {
         uint amountAuth =
-            _authorizer.getRoleMemberCount(_authorizer.getOwnerRole());
-        bytes32 ownerRole = _authorizer.getOwnerRole(); //To correctly time the vm.expectRevert
+            _authorizer.getRoleMemberCount(_authorizer.getAdminRole());
+        bytes32 adminRole = _authorizer.getAdminRole(); //To correctly time the vm.expectRevert
 
         vm.expectRevert(
             abi.encodeWithSelector(
                 IAuthorizer_v1
-                    .Module__Authorizer__OwnerRoleCannotBeEmpty
+                    .Module__Authorizer__AdminRoleCannotBeEmpty
                     .selector
             )
         );
         vm.prank(address(ALBA));
-        _authorizer.revokeRole(ownerRole, ALBA);
+        _authorizer.revokeRole(adminRole, ALBA);
 
-        assertEq(_authorizer.hasRole(ownerRole, ALBA), true);
+        assertEq(_authorizer.hasRole(adminRole, ALBA), true);
         assertEq(
-            _authorizer.getRoleMemberCount(_authorizer.getOwnerRole()),
+            _authorizer.getRoleMemberCount(_authorizer.getAdminRole()),
             amountAuth
         );
     }
@@ -371,7 +371,7 @@ contract AUT_RolesV1Test is Test {
         );
     }
 
-    function testGrantManagerRoleFailsIfNotOwner(address[] memory newAuthorized)
+    function testGrantManagerRoleFailsIfNotAdmin(address[] memory newAuthorized)
         public
     {
         // Here we test adding to a role that has OWNER as admin while not being OWNER
@@ -444,7 +444,7 @@ contract AUT_RolesV1Test is Test {
         assertEq(_authorizer.getRoleMemberCount(managerRole), amountManagers);
     }
 
-    function testRevokeManagerRoleFailsIfNotOwner(
+    function testRevokeManagerRoleFailsIfNotAdmin(
         address[] memory newAuthorized
     ) public {
         // Here we test adding to a role that has OWNER as admin while not being OWNER
@@ -868,7 +868,7 @@ contract AUT_RolesV1Test is Test {
         assertTrue(_authorizer.hasRole(globalRole, BOB));
     }
 
-    function testGrantGlobalRoleFailsIfNotOwner() public {
+    function testGrantGlobalRoleFailsIfNotAdmin() public {
         bytes32 globalRole =
             _authorizer.generateRoleId(address(_orchestrator), bytes32("0x03"));
         vm.prank(BOB);
@@ -878,7 +878,7 @@ contract AUT_RolesV1Test is Test {
     }
 
     // Test grantGlobalRoleBatched
-    // - Should revert if caller is not owner
+    // - Should revert if caller is not admin
     // - Should not revert if address list is empty
 
     function testGrantGlobalRoleBatched(address[] memory newAuthorized)
@@ -904,7 +904,7 @@ contract AUT_RolesV1Test is Test {
         }
     }
 
-    function testGrantGlobalRoleBatchedFailsIfCalledByNonOwner() public {
+    function testGrantGlobalRoleBatchedFailsIfCalledByNonAdmin() public {
         address newModule = _setupMockSelfManagedModule();
 
         bytes32 globalRole =
@@ -960,7 +960,7 @@ contract AUT_RolesV1Test is Test {
         vm.stopPrank();
     }
 
-    function testRevokeGlobalRoleFailsIfNotOwner() public {
+    function testRevokeGlobalRoleFailsIfNotAdmin() public {
         bytes32 globalRole =
             _authorizer.generateRoleId(address(_orchestrator), bytes32("0x03"));
 
@@ -975,7 +975,7 @@ contract AUT_RolesV1Test is Test {
     }
 
     // Test revokeGlobalRoleBatched
-    // - Should revert if caller is not owner
+    // - Should revert if caller is not admin
     // - Should not revert if address list is empty
 
     function testRevokeGlobalRoleBatched(address[] memory newAuthorized)
@@ -1003,7 +1003,7 @@ contract AUT_RolesV1Test is Test {
         vm.stopPrank();
     }
 
-    function testRevokeGlobalRoleBatchedFailsIfNotOwner() public {
+    function testRevokeGlobalRoleBatchedFailsIfNotAdmin() public {
         address newModule = _setupMockSelfManagedModule();
 
         bytes32 globalRole =
@@ -1053,7 +1053,7 @@ contract AUT_RolesV1Test is Test {
         assertTrue(_authorizer.hasRole(adminRole, BOB));
     }
 
-    function testGrantAdminRoleFailsIfNotOwner() public {
+    function testGrantAdminRoleFailsIfNotAdmin() public {
         bytes32 adminRole = _authorizer.DEFAULT_ADMIN_ROLE();
         address COBIE = address(0xC0B1E);
 
@@ -1063,7 +1063,7 @@ contract AUT_RolesV1Test is Test {
         assertFalse(_authorizer.hasRole(adminRole, COBIE));
     }
 
-    // Test that only Owner can change admin
+    // Test that only Admin can change admin
     function testChangeRoleAdminOnModuleRole() public {
         // First, we make BOB admin
         bytes32 adminRole = _authorizer.DEFAULT_ADMIN_ROLE();
@@ -1077,7 +1077,7 @@ contract AUT_RolesV1Test is Test {
 
         // Now we set the OWNER as Role admin
         vm.startPrank(BOB);
-        _authorizer.transferAdminRole(roleId, _authorizer.getOwnerRole());
+        _authorizer.transferAdminRole(roleId, _authorizer.getAdminRole());
         vm.stopPrank();
 
         // ALBA can now freely grant and revoke roles
@@ -1094,12 +1094,12 @@ contract AUT_RolesV1Test is Test {
         address newModule = _setupMockSelfManagedModule();
 
         bytes32 roleId = _authorizer.generateRoleId(newModule, ROLE_0);
-        bytes32 ownerRole = _authorizer.getOwnerRole(); //Buffer this to time revert
+        bytes32 adminRole = _authorizer.getAdminRole(); //Buffer this to time revert
 
         // BOB is not allowed to do this
         vm.startPrank(BOB);
         vm.expectRevert();
-        _authorizer.transferAdminRole(roleId, ownerRole);
+        _authorizer.transferAdminRole(roleId, adminRole);
         vm.stopPrank();
     }
 
@@ -1177,7 +1177,7 @@ contract AUT_RolesV1Test is Test {
     function _setupMockSelfManagedModule() internal returns (address) {
         ModuleV1Mock mockModule = new ModuleV1Mock();
 
-        vm.startPrank(ALBA); //We assume ALBA is owner
+        vm.startPrank(ALBA); //We assume ALBA is admin
         _orchestrator.initiateAddModuleWithTimelock(address(mockModule));
         vm.warp(block.timestamp + _orchestrator.MODULE_UPDATE_TIMELOCK());
         emit hm(_orchestrator.MODULE_UPDATE_TIMELOCK());

--- a/test/modules/authorizer/role/AUT_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_Roles_v1.t.sol
@@ -170,9 +170,15 @@ contract AUT_RolesV1Test is Test {
 
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
-        assertEq(testAuthorizer.hasRole("0x01", initialAuth), true);
+        assertEq(
+            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), initialAuth),
+            true
+        );
 
-        assertEq(testAuthorizer.hasRole("0x01", address(this)), false);
+        assertEq(
+            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), address(this)),
+            false
+        );
         assertEq(
             testAuthorizer.getRoleMemberCount(testAuthorizer.getOwnerRole()), 1
         );
@@ -195,7 +201,10 @@ contract AUT_RolesV1Test is Test {
 
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
-        assertEq(testAuthorizer.hasRole("0x01", address(this)), true);
+        assertEq(
+            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), address(this)),
+            true
+        );
         assertEq(
             testAuthorizer.getRoleMemberCount(testAuthorizer.getOwnerRole()), 1
         );
@@ -218,7 +227,10 @@ contract AUT_RolesV1Test is Test {
 
         assertEq(address(testAuthorizer.orchestrator()), address(_orchestrator));
 
-        assertEq(testAuthorizer.hasRole("0x01", initialAuth), true);
+        assertEq(
+            testAuthorizer.hasRole(testAuthorizer.getOwnerRole(), initialAuth),
+            true
+        );
 
         assertEq(
             testAuthorizer.getRoleMemberCount(testAuthorizer.getOwnerRole()), 1
@@ -240,9 +252,12 @@ contract AUT_RolesV1Test is Test {
             _METADATA,
             abi.encode(initialOwner, initialManager)
         );
-        assertEq(_authorizer.hasRole("0x01", address(this)), false);
+        assertEq(
+            _authorizer.hasRole(_authorizer.getOwnerRole(), address(this)),
+            false
+        );
         assertEq(address(_authorizer.orchestrator()), address(_orchestrator));
-        assertEq(_authorizer.hasRole("0x01", ALBA), true);
+        assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
         assertEq(_authorizer.getRoleMemberCount(_authorizer.getOwnerRole()), 1);
     }
 
@@ -1040,10 +1055,12 @@ contract AUT_RolesV1Test is Test {
 
     function testGrantAdminRoleFailsIfNotOwner() public {
         bytes32 adminRole = _authorizer.DEFAULT_ADMIN_ROLE();
+        address COBIE = address(0xC0B1E);
+
         vm.prank(BOB);
         vm.expectRevert();
-        _authorizer.grantRole(adminRole, ALBA);
-        assertFalse(_authorizer.hasRole(adminRole, ALBA));
+        _authorizer.grantRole(adminRole, COBIE);
+        assertFalse(_authorizer.hasRole(adminRole, COBIE));
     }
 
     // Test that only Owner can change admin
@@ -1171,7 +1188,7 @@ contract AUT_RolesV1Test is Test {
         vm.expectEmit(true, true, true, true);
         emit RoleAdminChanged(
             _authorizer.generateRoleId(address(mockModule), ROLE_1),
-            bytes32(0x0),
+            bytes32(0x00),
             _authorizer.BURN_ADMIN_ROLE()
         );
 

--- a/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
@@ -72,9 +72,9 @@ contract AUT_TokenGated_RolesV1Test is AUT_RolesV1Test {
             _authorizer.hasRole(_authorizer.getManagerRole(), address(this)),
             true
         );
-        assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
+        assertEq(_authorizer.hasRole(_authorizer.getAdminRole(), ALBA), true);
         assertEq(
-            _authorizer.hasRole(_authorizer.getOwnerRole(), address(this)),
+            _authorizer.hasRole(_authorizer.getAdminRole(), address(this)),
             false
         );
     }
@@ -158,9 +158,9 @@ contract TokenGatedAUT_RoleV1Test is Test {
             _authorizer.hasRole(_authorizer.getManagerRole(), address(this)),
             true
         );
-        assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
+        assertEq(_authorizer.hasRole(_authorizer.getAdminRole(), ALBA), true);
         assertEq(
-            _authorizer.hasRole(_authorizer.getOwnerRole(), address(this)),
+            _authorizer.hasRole(_authorizer.getAdminRole(), address(this)),
             false
         );
 

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -71,8 +71,8 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     ERC20Issuance_v1 issuanceToken;
 
-    address owner_address = address(0xA1BA);
-    address non_owner_address = address(0xB0B);
+    address admin_address = address(0xA1BA);
+    address non_admin_address = address(0xB0B);
 
     event Transfer(address indexed from, address indexed to, uint value);
 
@@ -148,7 +148,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
         _setUpOrchestrator(bondingCurveFundingManager);
 
-        _authorizer.grantRole(_authorizer.getOwnerRole(), owner_address);
+        _authorizer.grantRole(_authorizer.getAdminRole(), admin_address);
 
         // Init Module
         bondingCurveFundingManager.init(
@@ -156,7 +156,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
             _METADATA,
             abi.encode(
                 issuanceToken_properties,
-                owner_address,
+                admin_address,
                 bc_properties,
                 _token // fetching from ModuleTest.sol (specifically after the _setUpOrchestrator function call)
             )
@@ -307,7 +307,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         _prepareBuyConditions(buyer, amount);
 
         // we set a virtual collateral supply that will not cover the amount to redeem
-        vm.prank(owner_address);
+        vm.prank(admin_address);
         bondingCurveFundingManager.setVirtualCollateralSupply(
             type(uint).max - amount + 1
         );
@@ -341,7 +341,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         _prepareBuyConditions(buyer, amount);
 
         // we set a virtual collateral supply that will not cover the amount to redeem
-        vm.prank(owner_address);
+        vm.prank(admin_address);
         bondingCurveFundingManager.setVirtualIssuanceSupply(type(uint).max);
 
         vm.startPrank(buyer);
@@ -438,7 +438,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         );
         // see comment in testBuyOrderWithZeroFee for information on the upper bound
 
-        vm.prank(owner_address);
+        vm.prank(admin_address);
         bondingCurveFundingManager.setBuyFee(fee);
 
         address buyer = makeAddr("buyer");
@@ -628,7 +628,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         vm.assume(userSellAmount > 0); // we discard buy-ins so small they wouldn't cause underflow
 
         // we set a virtual collateral supply that will not cover the amount to redeem
-        vm.prank(owner_address);
+        vm.prank(admin_address);
         bondingCurveFundingManager.setVirtualIssuanceSupply(userSellAmount - 1);
 
         vm.startPrank(seller);
@@ -693,7 +693,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         // Set virtual collateral to some number
         uint newVirtualIssuanceSupply = userSellAmount * 2;
         uint newVirtualCollateral = amountIn * 2;
-        vm.startPrank(owner_address);
+        vm.startPrank(admin_address);
         {
             bondingCurveFundingManager.setVirtualIssuanceSupply(
                 newVirtualIssuanceSupply
@@ -805,7 +805,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         // Set virtual collateral to some number
         uint newVirtualIssuanceSupply = userSellAmount * 2;
         uint newVirtualCollateral = amountIn * 2;
-        vm.startPrank(owner_address);
+        vm.startPrank(admin_address);
         {
             bondingCurveFundingManager.setSellFee(fee);
             bondingCurveFundingManager.setVirtualIssuanceSupply(
@@ -918,7 +918,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         // Set virtual collateral to some number
         uint newVirtualIssuanceSupply = userSellAmount * 2;
         uint newVirtualCollateral = amountIn * 2;
-        vm.startPrank(owner_address);
+        vm.startPrank(admin_address);
         {
             bondingCurveFundingManager.setVirtualIssuanceSupply(
                 newVirtualIssuanceSupply
@@ -1031,7 +1031,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         uint _virtualIssuanceSupplyBeforeBuy = amountIn * 1000;
         uint _virtualCollateralSupplyBeforeBuy = minAmountOut * 1000;
 
-        vm.startPrank(owner_address);
+        vm.startPrank(admin_address);
         {
             bondingCurveFundingManager.setVirtualIssuanceSupply(
                 _virtualIssuanceSupplyBeforeBuy
@@ -1094,7 +1094,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         ); // We mint all the other tokens to the fundingManager to make sure we'll have enough balance to pay out
 
         // Set virtual supplies
-        vm.startPrank(owner_address);
+        vm.startPrank(admin_address);
         {
             bondingCurveFundingManager.setVirtualIssuanceSupply(
                 newVirtualIssuanceSupply
@@ -1153,7 +1153,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     function testGetVirtualCollateralSupply(uint _supply) public {
         vm.assume(_supply > 0);
 
-        vm.prank(owner_address);
+        vm.prank(admin_address);
         bondingCurveFundingManager.setVirtualCollateralSupply(_supply);
 
         assertEq(
@@ -1166,7 +1166,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     function testGetVirtualIssuanceSupply(uint _supply) public {
         vm.assume(_supply > 0);
 
-        vm.prank(owner_address);
+        vm.prank(admin_address);
         bondingCurveFundingManager.setVirtualIssuanceSupply(_supply);
 
         assertEq(_supply, bondingCurveFundingManager.getVirtualIssuanceSupply());
@@ -1181,21 +1181,21 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     function testMintIssuanceTokenTo(uint amount)
         public
         virtual
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
-        assertEq(issuanceToken.balanceOf(non_owner_address), 0);
+        assertEq(issuanceToken.balanceOf(non_admin_address), 0);
 
         bondingCurveFundingManager.mintIssuanceTokenTo(
-            non_owner_address, amount
+            non_admin_address, amount
         );
 
-        assertEq(issuanceToken.balanceOf(non_owner_address), amount);
+        assertEq(issuanceToken.balanceOf(non_admin_address), amount);
     }
 
     /* Test setVirtualIssuanceSupply and _setVirtualIssuanceSupply function
-        ├── when caller is not the Orchestrator_v1 owner
+        ├── when caller is not the Orchestrator_v1 admin
         │      └── it should revert (tested in base Module tests)
-        └── when caller is the Orchestrator_v1 owner
+        └── when caller is the Orchestrator_v1 admin
                 ├── when the new token supply is zero
                 │   └── it should revert
                 └── when the new token supply is above zero
@@ -1206,7 +1206,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetVirtualIssuanceSupply_FailsIfZero()
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         uint _newSupply = 0;
 
@@ -1220,7 +1220,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetVirtualIssuanceSupply(uint _newSupply)
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         vm.assume(_newSupply != 0);
 
@@ -1235,9 +1235,9 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     }
 
     /* Test setVirtualCollateralSupply and _setVirtualCollateralSupply function
-        ├── when caller is not the Orchestrator_v1 owner
+        ├── when caller is not the Orchestrator_v1 admin
         │      └── it should revert (tested in base Module tests)
-        └── when caller is the Orchestrator_v1 owner
+        └── when caller is the Orchestrator_v1 admin
                 ├── when the new collateral supply is zero
                 │   └── it should revert
                 └── when the new collateral supply is above zero
@@ -1248,7 +1248,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetVirtualCollateralSupply_FailsIfZero()
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         uint _newSupply = 0;
 
@@ -1262,7 +1262,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetVirtualCollateralSupply(uint _newSupply)
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         vm.assume(_newSupply != 0);
 
@@ -1277,9 +1277,9 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     }
 
     /* Test setReserveRatioForBuying and _setReserveRatioForBuying function
-        ├── when caller is not the Orchestrator_v1 owner
+        ├── when caller is not the Orchestrator_v1 admin
         │       └── it should revert (tested in base Module tests)
-        └── when caller is the Orchestrator_v1 owner
+        └── when caller is the Orchestrator_v1 admin
                 ├── when reserve ratio is  0% 
                 │       └── it should revert
                 ├── when reserve ratio is below 100%
@@ -1293,7 +1293,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     */
     function testSetReserveRatioForBuying_failsIfRatioIsZero()
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         vm.expectRevert(
             IFM_BC_Bancor_Redeeming_VirtualSupply_v1
@@ -1305,7 +1305,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetReserveRatioForBuying_failsIfRatioIsAboveMax(
         uint32 _newRatio
-    ) public callerIsOrchestratorOwner {
+    ) public callerIsOrchestratorAdmin {
         vm.assume(_newRatio > bondingCurveFundingManager.call_PPM());
         vm.expectRevert(
             IFM_BC_Bancor_Redeeming_VirtualSupply_v1
@@ -1317,7 +1317,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetReserveRatioForBuying(uint32 _newRatio)
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         //manual bound for uint32
         _newRatio = (_newRatio % bondingCurveFundingManager.call_PPM()) + 1; // reserve ratio of 0% isn't allowed, 100% is (although it isn't really a curve anymore)
@@ -1336,9 +1336,9 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     // Test reserve ratio changes
 
     /* Test setReserveRatioForSelling and _setReserveRatioForSelling function
-        ├── when caller is not the Orchestrator_v1 owner
+        ├── when caller is not the Orchestrator_v1 admin
         │       └── it should revert (tested in base Module tests)
-        └── when caller is the Orchestrator_v1 owner
+        └── when caller is the Orchestrator_v1 admin
                 ├── when reserve ratio is  0% 
                 │       └── it should revert
                 ├── when reserve ratio is below 100%
@@ -1352,7 +1352,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     */
     function testSetReserveRatioForSelling_failsIfRatioIsZero()
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         vm.expectRevert(
             IFM_BC_Bancor_Redeeming_VirtualSupply_v1
@@ -1364,7 +1364,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetReserveRatioForSelling_failsIfRatioIsAboveMax(
         uint32 _newRatio
-    ) public callerIsOrchestratorOwner {
+    ) public callerIsOrchestratorAdmin {
         vm.assume(_newRatio > bondingCurveFundingManager.call_PPM());
         vm.expectRevert(
             IFM_BC_Bancor_Redeeming_VirtualSupply_v1
@@ -1376,7 +1376,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
 
     function testSetReserveRatioForSelling(uint32 _newRatio)
         public
-        callerIsOrchestratorOwner
+        callerIsOrchestratorAdmin
     {
         //manual bound for uint32
         _newRatio = (_newRatio % bondingCurveFundingManager.call_PPM()) + 1; // reserve ratio of 0% isn't allowed, 100% is (although it isn't really a curve anymore)
@@ -1504,7 +1504,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         │       └── it should return the amount without change
         ├── when the token decimals are higher than the required decimals
         │       └── it should cut the excess decimals from the amount and return it
-        └── when caller is the Orchestrator_v1 owner
+        └── when caller is the Orchestrator_v1 admin
                 └── it should pad the amount by the missing decimals and return it
         */
 
@@ -1565,7 +1565,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     /* Test transferOrchestratorToken 
         ├── when caller is not the Orchestrator_v1 
         │      └── it should revert (tested in base Module tests)
-        └── when caller is the Orchestrator_v1 owner
+        └── when caller is the Orchestrator_v1 admin
                 ├── it should send the funds to the specified address
                 └── it should emit an event?
     */
@@ -1597,10 +1597,10 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     //--------------------------------------------------------------------------
     // Helper functions
 
-    // Modifier to ensure the caller has the owner role
-    modifier callerIsOrchestratorOwner() {
-        _authorizer.grantRole(_authorizer.getOwnerRole(), owner_address);
-        vm.startPrank(owner_address);
+    // Modifier to ensure the caller has the admin role
+    modifier callerIsOrchestratorAdmin() {
+        _authorizer.grantRole(_authorizer.getAdminRole(), admin_address);
+        vm.startPrank(admin_address);
         _;
     }
 

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -69,7 +69,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1UpstreamTests is
 
         _setUpOrchestrator(bondingCurveFundingManager);
 
-        _authorizer.grantRole(_authorizer.getOwnerRole(), owner_address);
+        _authorizer.grantRole(_authorizer.getAdminRole(), admin_address);
 
         // Init Module
         bondingCurveFundingManager.init(
@@ -77,7 +77,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1UpstreamTests is
             _METADATA,
             abi.encode(
                 issuanceToken_properties,
-                owner_address,
+                admin_address,
                 bc_properties,
                 _token // fetching from ModuleTest.sol (specifically after the _setUpOrchestrator function call)
             )
@@ -95,7 +95,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1UpstreamTests is
         address[] memory targets = new address[](3);
         targets[0] = buyer;
         targets[1] = seller;
-        targets[2] = owner_address;
+        targets[2] = admin_address;
 
         bondingCurveFundingManager.grantModuleRoleBatched(
             CURVE_INTERACTION_ROLE, targets
@@ -131,9 +131,9 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1UpstreamTests is
 
     // Override to test deactivation
     function testMintIssuanceTokenTo(uint amount) public override {
-        assertEq(issuanceToken.balanceOf(non_owner_address), 0);
+        assertEq(issuanceToken.balanceOf(non_admin_address), 0);
 
-        vm.startPrank(address(owner_address));
+        vm.startPrank(address(admin_address));
         {
             vm.expectRevert(
                 abi.encodeWithSelector(
@@ -144,12 +144,12 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1UpstreamTests is
             );
 
             bondingCurveFundingManager.mintIssuanceTokenTo(
-                non_owner_address, amount
+                non_admin_address, amount
             );
         }
         vm.stopPrank();
 
-        assertEq(_token.balanceOf(non_owner_address), 0);
+        assertEq(_token.balanceOf(non_admin_address), 0);
     }
 }
 
@@ -176,8 +176,8 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Tests is
 
     ERC20Issuance_v1 issuanceToken;
 
-    address owner_address = address(0xA1BA);
-    address non_owner_address = address(0xB0B);
+    address admin_address = address(0xA1BA);
+    address non_admin_address = address(0xB0B);
 
     function setUp() public {
         // Deploy contracts
@@ -213,7 +213,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Tests is
 
         _setUpOrchestrator(bondingCurveFundingManager);
 
-        _authorizer.grantRole(_authorizer.getOwnerRole(), owner_address);
+        _authorizer.grantRole(_authorizer.getAdminRole(), admin_address);
 
         // Init Module
         bondingCurveFundingManager.init(
@@ -221,7 +221,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Tests is
             _METADATA,
             abi.encode(
                 issuanceToken_properties,
-                owner_address,
+                admin_address,
                 bc_properties,
                 _token // fetching from ModuleTest.sol (specifically after the _setUpOrchestrator function call)
             )
@@ -401,7 +401,7 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Tests is
         address _receiver = makeAddr("receiver");
         uint _mintAmount = 1;
 
-        bytes32 _roleId = _authorizer.getOwnerRole();
+        bytes32 _roleId = _authorizer.getAdminRole();
 
         vm.startPrank(_minter);
         {

--- a/test/modules/logicModule/LM_PC_Staking_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_Staking_v1.t.sol
@@ -468,11 +468,11 @@ contract LM_PC_Staking_v1Test is ModuleTest {
     }
 
     function testSetRewardsModifierInPosition() public {
-        //onlyOrchestratorOwnerOrManager
+        //onlyOrchestratorAdminOrManager
         vm.expectRevert(
             abi.encodeWithSelector(
                 IModule_v1.Module__CallerNotAuthorized.selector,
-                _authorizer.getOwnerRole(),
+                _authorizer.getAdminRole(),
                 address(0xBEEF)
             )
         );

--- a/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
+++ b/test/modules/logicModule/oracle/OptimisticOracleIntegrator.t.sol
@@ -156,9 +156,9 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
     // Setter Functions
 
     /*
-        When the caller is not the owner
+        When the caller is not the admin
             reverts (tested in module tests)
-        When the caller is the owner
+        When the caller is the admin
             when the address is 0
                 reverts
             when the address is a valid token
@@ -189,9 +189,9 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
     }
 
     /*
-        When the caller is not the owner
+        When the caller is not the admin
             reverts (tested in module tests)
-        When the caller is the owner
+        When the caller is the admin
             when the address is 0
                 reverts
             when the address is not an UMA OO instance 
@@ -227,9 +227,9 @@ contract OptimisticOracleIntegratorTest is ModuleTest {
     }
 
     /*
-        When the caller is not the owner
+        When the caller is not the admin
             reverts (tested in module tests)
-        When the caller is the owner
+        When the caller is the admin
             when the liveness is 0
                 reverts
             when the liveness is valid 

--- a/test/modules/logicModule/oracle/utils/OptimisiticOracleV3Mock.sol
+++ b/test/modules/logicModule/oracle/utils/OptimisiticOracleV3Mock.sol
@@ -52,7 +52,7 @@ contract OptimisticOracleV3Mock is OptimisticOracleV3Interface {
 
     /**
      * @notice Sets the default currency, liveness, and burned bond percentage.
-     * @dev Only callable by the contract owner (UMA governor).
+     * @dev Only callable by the contract admin (UMA governor).
      * @param _defaultCurrency the default currency to bond asserters in assertTruthWithDefaults.
      * @param _defaultLiveness the default liveness for assertions in assertTruthWithDefaults.
      * @param _burnedBondPercentage the percentage of the bond that is sent as fee to UMA Store contract on disputes.

--- a/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
@@ -241,11 +241,11 @@ contract LM_PC_RecurringV1Test is ModuleTest {
         //Warp to a reasonable time
         vm.warp(2 weeks);
 
-        //onlyOrchestratorOwnerOrManager
+        //onlyOrchestratorAdminOrManager
         vm.expectRevert(
             abi.encodeWithSelector(
                 IModule_v1.Module__CallerNotAuthorized.selector,
-                _authorizer.getOwnerRole(),
+                _authorizer.getAdminRole(),
                 address(0xBEEF)
             )
         );
@@ -368,11 +368,11 @@ contract LM_PC_RecurringV1Test is ModuleTest {
             _orchestrator, _METADATA, abi.encode(1 weeks)
         );
 
-        //onlyOrchestratorOwnerOrManager
+        //onlyOrchestratorAdminOrManager
         vm.expectRevert(
             abi.encodeWithSelector(
                 IModule_v1.Module__CallerNotAuthorized.selector,
-                _authorizer.getOwnerRole(),
+                _authorizer.getAdminRole(),
                 address(0xBEEF)
             )
         );

--- a/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
@@ -1001,7 +1001,7 @@ contract PP_StreamingV1Test is //@note do we want to do anything about these tes
 
         assertTrue(expectedTotal != 0);
 
-        vm.prank(address(this)); // stupid line, ik, but it's just here to show that onlyOrchestratorOwner can call the next function
+        vm.prank(address(this)); // stupid line, ik, but it's just here to show that onlyOrchestratorAdmin can call the next function
         paymentProcessor.removePaymentForSpecificStream(
             address(paymentClient), paymentReceiver1, walletId
         );
@@ -1130,7 +1130,7 @@ contract PP_StreamingV1Test is //@note do we want to do anything about these tes
 
         assertTrue(total2 != 0);
 
-        vm.prank(address(this)); // stupid line, ik, but it's just here to show that onlyOrchestratorOwner can call the next function
+        vm.prank(address(this)); // stupid line, ik, but it's just here to show that onlyOrchestratorAdmin can call the next function
         paymentProcessor.removePaymentForSpecificStream(
             address(paymentClient),
             paymentReceiver1,

--- a/test/orchestrator/Orchestrator_v1.t.sol
+++ b/test/orchestrator/Orchestrator_v1.t.sol
@@ -275,10 +275,10 @@ contract OrchestratorV1Test is Test {
 
         // verify whether the init value is set and not the value from the old
         // authorizer, to check whether the replacement is successful
-        bytes32 ownerRole = orchestrator.authorizer().getOwnerRole();
-        assertFalse(orchestrator.authorizer().hasRole(ownerRole, address(this)));
+        bytes32 adminRole = orchestrator.authorizer().getAdminRole();
+        assertFalse(orchestrator.authorizer().hasRole(adminRole, address(this)));
         assertTrue(
-            orchestrator.authorizer().hasRole(ownerRole, address(0xA11CE))
+            orchestrator.authorizer().hasRole(adminRole, address(0xA11CE))
         );
     }
 
@@ -743,7 +743,7 @@ contract OrchestratorV1Test is Test {
         vm.expectRevert(
             abi.encodeWithSelector(
                 IOrchestrator_v1.Orchestrator__CallerNotAuthorized.selector,
-                authorizer.getOwnerRole(),
+                authorizer.getAdminRole(),
                 address(this)
             )
         );

--- a/test/utils/mocks/modules/AuthorizerV1Mock.sol
+++ b/test/utils/mocks/modules/AuthorizerV1Mock.sol
@@ -134,7 +134,7 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
         _roleAuthorized[role][who] = false;
     }
 
-    function getOwnerRole() external pure returns (bytes32) {
+    function getAdminRole() external pure returns (bytes32) {
         return "0x00";
     }
 

--- a/test/utils/mocks/modules/AuthorizerV1Mock.sol
+++ b/test/utils/mocks/modules/AuthorizerV1Mock.sol
@@ -53,7 +53,7 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
 
         _authorized[authorized] = true;
 
-        _roleAuthorized["0x01"][msg.sender] = true;
+        _roleAuthorized["0x00"][msg.sender] = true;
         _roleAuthorized["0x02"][msg.sender] = true;
     }
 
@@ -135,7 +135,7 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
     }
 
     function getOwnerRole() external pure returns (bytes32) {
-        return "0x01";
+        return "0x00";
     }
 
     function getManagerRole() external pure returns (bytes32) {
@@ -182,7 +182,7 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
     }
 
     function getRoleAdmin(bytes32) external pure returns (bytes32) {
-        revert("Not implemented in Authorizer Mock");
+        return "0x00"; // In this mock, all roles have the owner as admin
     }
 
     function getRoleMember(bytes32, uint) external pure returns (address) {

--- a/test/utils/mocks/orchestrator/OrchestratorV1AccessMock.sol
+++ b/test/utils/mocks/orchestrator/OrchestratorV1AccessMock.sol
@@ -117,8 +117,6 @@ contract OrchestratorV1AccessMock is IOrchestrator_v1 {
 
     function version() external pure returns (string memory) {}
 
-    function owner() external view returns (address) {}
-
     function manager() external view returns (address) {}
 
     function findModuleAddressInOrchestrator(string calldata moduleName)


### PR DESCRIPTION
## What has been done
- Corrected the gating of grantModuleRole so only the admin of that role can modify it
- Merged DEFAULT_ADMIN_ROLE and ORCHESTRATOR_OWNER_ROLE into one. Now the owner has full admin control, and modules can selectively opt out on a per-role basis. Before this the OWNER had to grant themselves ADMIN role first (which they could do anyway), so the trust assumptions don't change.