### PR TITLE
[SC-434] Chore: Update Readmes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 <img align="right" width="150" height="150" top="100" src="./assets/logo_circle.svg">
 
-# Contributing to the Inverter Network Contracts
+# Contribution Guidelines
 
-Thanks for your interest in improving the Inverter Network contracts! Your contributions play a vital role in enhancing the robustness and usability of the network. Open-source projects like ours thrive on community collaboration, and every contribution, big or small, pushes us closer to our shared vision.
+Thanks for your interest in improving the Inverter Network contracts! Your contributions play a vital role in enhancing the robustness and usability of the protocol. Open-source projects like ours thrive on community collaboration, and every contribution, big or small, pushes us closer to our shared vision.
 
 ## Using GitHub Issues
 GitHub issues are an essential tool for collaboration and tracking in our project. If you're an external contributor and come across something that isn't working as expected or have suggestions, concerns, or any other reasons to reach out:
@@ -15,14 +15,16 @@ Remember, every issue opened helps improve the project, and your feedback is inv
 ## Branching System
 
 We operate using a two-branch-system:
-- **main**: This is our stable branch. Releases are made from this branch.
-- **dev**: Development and feature integration happens here.
+- **main**: This is our stable branch. The contents of this branch are deployed to our live networks.
+- **dev**: Development and feature integration happens here. The contents of this branch are deployed on our testnet.
 
 ## Workflow
 1. Create feature branches from `dev` when working on any new feature or bug fix.
+   - External contributors may need to fork the repository first and work from there.
 2. Once your feature is complete, create a PR to merge from your feature branch into `dev`.
+   - We require multiple reviews from our side as a prerequisite to merging into `dev`.
 3. When ready to release to `main`, the team will create a PR from `dev` to `main`.
-4. External contributors are welcome to create PRs that merge into `dev`.
+   - Our process for merging from `dev` to `main` requires multiple internal as well as external reviews (via an audit).
 
 ## Criteria for Pull Requests
 
@@ -36,15 +38,17 @@ By following these principles, you ensure that the Inverter Network contracts re
 ### Merging into `dev`
 Your PR should have:
 - Full test coverage of the new feature, following the style of the existing tests.
+  - This including adapting the E2E tests accordingly if the feature requires it.
 - Updated deployment scripts (if necessary).
 - Proper code comments.
 - Ensure the GitHub Continuous Integration (CI) and Linter checks pass without errors.
+  - A good way to locally verify this, is via running the `make pre-commit` command (more details in our <a href="./README.md" target="_blank">README.md</a>).
 
 ### Merging into `main`
 Your PR should have:
 - Everything listed in the requirements for `dev` (fully tested, updated deployment scripts, code comments, etc.)
-- Full documentation coverage in the wiki. Draft the documentation in the PR comments.
-- Review of the requirements (according to the following section) by the developers and QA
+- Full documentation coverage.
+- Review of the requirements (according to the following section) by the developers and QA.
 
 ### Requirements Verification
 For feature implementations that are guided by an SRS document or a similar specification:
@@ -59,28 +63,13 @@ For feature implementations that are guided by an SRS document or a similar spec
 This ensures that reviewers can efficiently evaluate the correctness of the implementation against the defined requirements.
 
 ## Deployment Criteria
-Whenever these branches are updated, it triggers a redeployment on the corresponding blockchain network. Currently, these redeployments are done manually. The latest deployment details will be in the <a href="./README.md" target="_blank">README.md</a> file.
+Whenever these branches are updated, it triggers a redeployment on the corresponding blockchain network. Currently, these redeployments are done manually. The latest deployment details will be in the <a href="https://github.com/InverterNetwork/deployments" target="_blank">deployments repository</a>.
 
-**Minor Changes**: Only the affected contract will be redeployed if the update is a minor change or a bug fix.
-**Fundamental Changes**: If there's a significant feature addition or a substantial change, a full redeployment will be executed to ensure all components are in sync.
+* **Minor Changes**: Only the affected contract will be redeployed if the update is a minor change or a bug fix.
+* **Fundamental Changes**: If there's a significant feature addition or a substantial change, a full redeployment will be executed to ensure all components are in sync.
+
 This deployment strategy ensures that our contracts are always up-to-date and tested in real-world scenarios.
 
-## Resolving an Issue
+-----
+_Disclaimer: Originally adapted from the [ethers-rs contributing guide](https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md)._
 
-Pull requests are the way concrete changes are made to the code, documentation,
-and dependencies of the Inverter Network.
-
-Even tiny pull requests, like fixing wording, are greatly appreciated.
-Before making a large change, it is usually a good idea to first open an issue
-describing the change to solicit feedback and guidance. This will increase the
-likelihood of the PR getting merged.
-
-Please also make sure to run our pre-commit hook before creating a PR:
-
-```bash
-make pre-commit
-```
-
-This hook will update gas and code coverage metrics, format the code, run the tests, and verify that all scripts work as expected.
-
-_DISCLAIMER: Originally adapted from the [ethers-rs contributing guide](https://github.com/gakonst/ethers-rs/blob/master/CONTRIBUTING.md)._

--- a/Makefile
+++ b/Makefile
@@ -22,29 +22,27 @@ endif
 # -----------------------------------------------------------------------------
 # Common
 .PHONY: clean
-clean: ## Remove build artifacts
+clean: # Remove build artifacts
 	@forge clean
 
 .PHONY: install
-install: ## Installs the required dependencies
+install: # Installs the required dependencies
 	@forge install
 
 .PHONY: build
-build: ## Build project
+build: # Build project
 	@forge build
 
 .PHONY: update
-update: ## Update dependencies
+update: # Update dependencies
 	@forge update
 
 .PHONY: test
-test: ## Run whole testsuite
+test: # Run whole test suite
 	@forge test -vvv
 
-.PHONY: testFuzz .DEFAULT
-.DEFAULT:
-	@:
-testFuzz: ## Run whole testsuite with a custom amount of fuzz runs
+.PHONY: testFuzz
+testFuzz: # Run whole test suite with a custom amount of fuzz runs
 	@if [ "$(filter-out $@,$(MAKECMDGOALS))" -ge 1 ] 2>/dev/null; then \
 		export FOUNDRY_FUZZ_RUNS=$(filter-out $@,$(MAKECMDGOALS)); \
 	else \
@@ -63,28 +61,28 @@ testFuzz: ## Run whole testsuite with a custom amount of fuzz runs
 # Individual Component Tests
 
 .PHONY: testOrchestrator
-testOrchestrator: ## Run orchestrator/ package tests
+testOrchestrator: # Run orchestrator/ package tests
 	@make pre-test
 	@forge test -vvv --match-path "*/orchestrator/*"
 
 .PHONY: testModules
-testModules: ## Run modules/ package tests
+testModules: # Run modules/ package tests
 	@make pre-test
 	@forge test -vvv --match-path "*/modules/*"
 
 .PHONY: testFactories
-testFactories: ## Run factories/ package tests
+testFactories: # Run factories/ package tests
 	@make pre-test
 	@forge test -vvv --match-path "*/factories/*"
 
 .PHONY: testE2e
-testE2e: ## Run e2e test suite
+testE2e: # Run e2e test suite
 	@make pre-test
 	@forge test -vvv --match-path "*/e2e/*"
 
 .PHONY: testScripts
-testScripts: ## Run e2e test suite
-	@echo "# Run scripts"
+testScripts: # Run e2e test suite
+	@echo "### Run scripts"
  	
 	## external
 	@forge script script/external/DeployGovernor_v1.s.sol
@@ -130,7 +128,7 @@ testScripts: ## Run e2e test suite
 # Static Analyzers
 
 .PHONY: analyze-slither
-analyze-slither: ## Run slither analyzer against project (requires solc-select)
+analyze-slither: # Run slither analyzer against project (requires solc-select)
 	@forge build --extra-output abi --extra-output userdoc --extra-output devdoc --extra-output evm.methodIdentifiers
 	@solc-select use 0.8.19
 	@slither --ignore-compile src/common   || \
@@ -140,18 +138,18 @@ analyze-slither: ## Run slither analyzer against project (requires solc-select)
 	slither --ignore-compile src/proposal
 
 .PHONY: analyze-c4udit
-analyze-c4udit: ## Run c4udit analyzer against project
+analyze-c4udit: # Run c4udit analyzer against project
 	@c4udit src
 
 # -----------------------------------------------------------------------------
 # Reports
 
 .PHONY: report-gas
-report-gas: ## Print gas report
+report-gas: # Print gas report
 	@forge test --gas-report
 
 .PHONY: report-cov
-report-cov: ## Print coverage report
+report-cov: # Print coverage report
 	@echo "### Running tests & generating the coverage report..."
 	@forge coverage --report lcov
 	@genhtml lcov.info --branch-coverage --output-dir coverage
@@ -161,11 +159,11 @@ report-cov: ## Print coverage report
 # Formatting
 
 .PHONY: fmt
-fmt: ## Format code
+fmt: # Format code
 	@forge fmt
 
 .PHONY: fmt-check
-fmt-check: ## Check whether code formatted correctly
+fmt-check: # Check whether code formatted correctly
 	@forge fmt --check
 
 # -----------------------------------------------------------------------------
@@ -175,13 +173,13 @@ pre-test: # format and export correct data
 	@echo "### Formatting..."
 	@forge fmt
 
-	@echo "# Env variables to make sure the local tests runs"
-	@echo "# equally long compared to the CI tests"
+	@echo "### Env variables to make sure the local tests runs"
+	@echo "### equally long compared to the CI tests"
 	@export FOUNDRY_FUZZ_RUNS=1024
 	@export FOUNDRY_FUZZ_MAX_TEST_REJECTS=65536
 
 .PHONY: pre-commit
-pre-commit: ## Git pre-commit hook
+pre-commit: # Git pre-commit hook
 
 	@echo "### Running the scripts"
 	@make testScripts
@@ -196,5 +194,5 @@ pre-commit: ## Git pre-commit hook
 # Help Command
 
 .PHONY: help
-help:
-	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+help: # Show help for each of the Makefile recipes
+	@grep -E '^[a-zA-Z0-9 -]+:.*#'  Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Inverter Network smart contracts are developed using the [foundry toolchain]
 Common tasks are executed through a `Makefile`. The most common commands are:
 * `make build` to compile the project.
 * `make test` to run the test suite.
-  * Note: _Some of our tests  require a working Sepolia RPC URL, as we test certain contracts via fork testing. We implemented fallbacks in these cases in the code directly, so they should work even without any RPC set in the environment. If that does not work, please set a working one via `export SEPOLIA_RPC_URL=https://rpc-url-here`._
+  * Note: _Some of our tests  require a working Sepolia RPC URL, as we test certain contracts via fork testing. We implemented fallbacks for these particular test cases in the code directly, so they will work even without any RPC set in the environment. In the unlikely case that the tests do not work without RPC, please set a working one via `export SEPOLIA_RPC_URL=https://rpc-url-here`._
 * `make pre-commit` to ensure all of the development requirements are met, such as
   * the Foundry Formatter has been run.
   * the scripts are all working.
@@ -35,7 +35,7 @@ $ make help
 ```
 
 ## Documentation
-A technical documentation can be found in our **[GitHub Wiki](https://github.com/InverterNetwork/inverter-contracts/wiki)**.
+The protocol is based on our [technical specification](https://docs.google.com/document/d/1j6WXBZzyYCOfO36ZYvKkgqrO2UAcy0kW5eJeZousn7E), which outlines its architecture and is the foundation of the implementation. Our documentation can be found [here](https://docs.inverter.network).
 
 ## Dependencies
 - [OpenZeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <a href="https://inverter.network" target="_blank"><img align="right" width="150" height="150" top="100" src="./assets/logo_circle.svg"></a>
 
 # Inverter Network Smart Contracts
-*Build, customize, and innovate with Inverter's modular logic and extensive web3 interoperability.*
+*Inverter is the pioneering web3 protocol for token economies, enabling conditional token issuance, dynamic utility management, and token distribution. Build, customize, and innovate with Inverter's modular logic and extensive web3 interoperability.*
 
 ## Installation
 
@@ -14,9 +14,16 @@ The Inverter Network smart contracts are developed using the [foundry toolchain]
 
 ## Usage
 
-Common tasks are executed through a `Makefile`.
+Common tasks are executed through a `Makefile`. The most common commands are:
+* `make build` to compile the project.
+* `make test` to run the test suite.
+  * Note: _Some of our tests  require a working Sepolia RPC URL, as we test certain contracts via fork testing. We implemented fallbacks in these cases in the code directly, so they should work even without any RPC set in the environment. If that does not work, please set a working one via `export SEPOLIA_RPC_URL=https://rpc-url-here`._
+* `make pre-commit` to ensure all of the development requirements are met, such as
+  * the Foundry Formatter has been run.
+  * the scripts are all working.
+  * the tests all run without any issues.
 
-The `Makefile` supports a help command, i.e. `make help`.
+Additionally, the `Makefile` supports a help command, i.e. `make help`.
 
 ```
 $ make help
@@ -31,14 +38,15 @@ $ make help
 A technical documentation can be found in our **[GitHub Wiki](https://github.com/InverterNetwork/inverter-contracts/wiki)**.
 
 ## Dependencies
-
 - [OpenZeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts)
 - [OpenZeppelin Upgradeable-Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable)
+- [UMAProtocol](https://github.com/UMAprotocol/protocol) (_for the [KPIRewarder Staking Module](./src/modules/logicModule/LM_PC_KPIRewarder_v1.sol)_)
+
+## Contributing
+You are considering to contribute to our protocol? Awesome - please refer to our [Contribution Guidelines](./CONTRIBUTING.md) to find our about the processes we established to ensure highest quality within our codebase.
 
 ## Safety
+Our [Security Policy](./SECURITY.md) provides details about our Security Guidelines, audits, and more. If you have discovered a potential security vulnerability within the Inverter Protocol, please report it to us by emailing [security@inverter.network](mailto:security@inverter.network).
 
-This is experimental software and is provided on an "as is" and
-"as available" basis.
-
-We do not give any warranties and will not be liable for any loss incurred
-through any use of this codebase.
+-----
+_Disclaimer: This is experimental software and is provided on an "as is" and "as available" basis. We do not give any warranties and will not be liable for any loss incurred through any use of this codebase._

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+<img align="right" width="150" height="150" top="100" src="./assets/logo_circle.svg">
+
+# Security Policy
+
+At Inverter Network, we are committed to ensuring the security and integrity of our protocol and smart contracts. We value the input of the community and security researchers in identifying and responsibly disclosing any potential vulnerabilities or security issues.
+
+## Reporting Security Issues
+
+If you discover a potential security vulnerability or issue within our smart contracts or any part of the Inverter Network ecosystem, we strongly encourage you to report it promptly. Please email [security@inverter.network](mailto:security@inverter.network) with a detailed description of the issue, steps to reproduce it, and any relevant information that can assist us in understanding and resolving the problem.
+
+We appreciate your efforts to disclose any security findings responsibly, and we are committed to collaborating with you to address the issue. Rest assured that you will be given proper credit for your contribution.
+
+## Responsible Disclosure
+
+Please practice responsible disclosure when reporting security issues. We kindly request that you do not publicly disclose or discuss the vulnerability until we have had sufficient time to investigate and address it. Privately disclosing the issue to us via email allows us to work on a fix without putting our users' funds at risk.
+
+We understand the importance of acknowledging and rewarding security researchers for their efforts. Even though our bug bounty program is currently set up, we assure you that you will not be unpaid for your valuable contributions. We are committed to fairly compensating those who help us improve the security of our platform.
+
+## Security Reviews and Audits
+
+At Inverter Network, we prioritize the security of our smart contracts and follow a rigorous process of security reviews and audits:
+
+* Per our development and security guidelines, we require an external review for each pull request (PR) that goes from the `dev` branch to the `main` branch in our repository. We have partnered with [Team Omega](https://teamomega.eth.limo) to conduct these security reviews directly in the PRs.
+
+* Additionally, prior to major releases, we perform a full audit of any changed contracts via an external auditing company before the deployment. This ensures that our contracts undergo thorough scrutiny by professional auditors.
+
+* Our version 1 has been audited by [0xMacro](https://0xmacro.com/). The audit report will be published here once it becomes public. Furthermore, our v1 is currently undergoing a public audit competition on [Hats Finance](https://hats.finance/), leveraging the expertise of the broader security community.
+
+We are committed to transparency and will make the results of our security reviews and audits available to the public, fostering trust and confidence in the security of our platform.
+
+## Security Guideline
+
+At Inverter Network, we adhere to a comprehensive Security Guideline that outlines our best practices and approach to ensuring the security of our smart contracts. This guideline is a public document that we follow at all times. You can find our Security Guideline [here](https://docs.google.com/document/d/1CZgM9OEuibNrimbNeActve5n9ro3Ydu03OfSnZfRo_s).
+
+We encourage you to review our Security Guideline to understand our commitment to security and the measures we have in place to protect our users and the integrity of our platform.
+
+## Bug Bounty Program
+
+We are currently in the process of setting up a bug bounty program to incentivize and reward security researchers for their contributions. Further details about the program will be announced once it is officially launched. Stay tuned for updates on how you can participate and be rewarded for your efforts in strengthening the security of the Inverter Network.
+
+## Contact Us
+
+If you have any questions, concerns, or feedback regarding the security of the Inverter Network, please don't hesitate to reach out to us at [security@inverter.network](mailto:security@inverter.network). We value open communication and collaboration with the security community.
+
+-----
+_Disclaimer: This is experimental software and is provided on an "as is" and "as available" basis. We do not give any warranties and will not be liable for any loss incurred through any use of this codebase._

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -123,7 +123,28 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
     function setUp() public override {
         // Pin tests to a block o save in RPC calls
         uint forkBlock = 5_723_995; //April 18 2024 12:15 EST
-        sepoliaForkId = vm.createSelectFork(vm.rpcUrl("sepolia"), forkBlock);
+
+        // Get RPC URL from the foundry.toml via the environment
+        // if that fails, set the fallback rpc url
+        string memory rpcUrl;
+        try vm.rpcUrl("sepolia") returns (string memory url) {
+            rpcUrl = url;
+        } catch {
+            console.log(
+                "Failed to get valid rpc url for sepolia from env, using fallback"
+            );
+            rpcUrl = vm.rpcUrl("https://rpc2.sepolia.org/");
+        }
+
+        // Try creating the fork via the rpc url set above
+        // if that fails, we alert the user about this
+        try vm.createSelectFork(rpcUrl, forkBlock) returns (uint forkId) {
+            sepoliaForkId = forkId;
+        } catch {
+            revert(
+                "Failed to create fork, missing working Sepolia RPC URL - Check README.md"
+            );
+        }
 
         // We deploy and label the necessary tokens for the tests
         USDC = ERC20Mock(USDC_address); //we use it  mock so we can call mint functions


### PR DESCRIPTION
This PR updates the readmes of the repo to represent the latest state and be prepared for a public release.
Changes:
* README and CONTRIBUTING revised
* SECURITY added
* Makefile updated to work accordingly (help command wasn't working)
* Update the test file that requires a working Sepolia RPC URL to work with a pre-set fallback URL (the official Sepolia RPC URL for Europe)
  * Goal: new users just wanting to run the tests can just run them without searching for any RPC URLs.
  * We can still locally overwrite it in `.env` files via `SEPOLIA_RPC_URL`, it's just a fallback