### PR TITLE
[SC-477] Remove OrchestratorManager role

### DIFF
--- a/script/setup/SetupToyOrchestratorScript.s.sol
+++ b/script/setup/SetupToyOrchestratorScript.s.sol
@@ -87,8 +87,7 @@ contract SetupToyOrchestratorScript is Test, DeploymentScript {
         // Authorizer: Metadata, initial authorized addresses
         IOrchestratorFactory_v1.ModuleConfig memory authorizerFactoryConfig =
         IOrchestratorFactory_v1.ModuleConfig(
-            roleAuthorizerMetadata,
-            abi.encode(orchestratorOwner, orchestratorOwner)
+            roleAuthorizerMetadata, abi.encode(orchestratorOwner)
         );
 
         // BountyManager: Metadata, salary precision, fee percentage, fee treasury address

--- a/script/utils/InvestableWorkstreams/01-DeployInvestableWorkstream.s.sol
+++ b/script/utils/InvestableWorkstreams/01-DeployInvestableWorkstream.s.sol
@@ -154,8 +154,7 @@ contract SetupInvestableWorkstream is Test, DeploymentScript {
         // Authorizer: Metadata, initial authorized addresses
         IOrchestratorFactory_v1.ModuleConfig memory authorizerFactoryConfig =
         IOrchestratorFactory_v1.ModuleConfig(
-            roleAuthorizerMetadata,
-            abi.encode(orchestratorOwner, orchestratorOwner)
+            roleAuthorizerMetadata, abi.encode(orchestratorOwner)
         );
 
         // Bounty Manager:

--- a/src/modules/authorizer/IAuthorizer_v1.sol
+++ b/src/modules/authorizer/IAuthorizer_v1.sol
@@ -102,8 +102,4 @@ interface IAuthorizer_v1 is IAccessControlEnumerable {
     /// @notice Returns the role ID of the owner role
     /// @return The role ID
     function getOwnerRole() external view returns (bytes32);
-
-    /// @notice Returns the role ID of the manager role
-    /// @return The role ID
-    function getManagerRole() external view returns (bytes32);
 }

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -53,7 +53,6 @@ contract AUT_Roles_v1 is
 
     // Stored for easy public reference. Other Modules can assume the following roles to exist
     bytes32 public constant ORCHESTRATOR_OWNER_ROLE = "0x01";
-    bytes32 public constant ORCHESTRATOR_MANAGER_ROLE = "0x02";
 
     bytes32 public constant BURN_ADMIN_ROLE =
         0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
@@ -96,13 +95,12 @@ contract AUT_Roles_v1 is
     ) external override initializer {
         __Module_init(orchestrator_, metadata);
 
-        (address initialOwner, address initialManager) =
-            abi.decode(configData, (address, address));
+        (address initialOwner) = abi.decode(configData, (address));
 
-        __RoleAuthorizer_init(initialOwner, initialManager);
+        __RoleAuthorizer_init(initialOwner);
     }
 
-    function __RoleAuthorizer_init(address initialOwner, address initialManager)
+    function __RoleAuthorizer_init(address initialOwner)
         internal
         onlyInitializing
     {
@@ -116,12 +114,6 @@ contract AUT_Roles_v1 is
         _setRoleAdmin(ORCHESTRATOR_OWNER_ROLE, ORCHESTRATOR_OWNER_ROLE);
         // -> set OWNER as admin of DEFAULT_ADMIN_ROLE
         _setRoleAdmin(DEFAULT_ADMIN_ROLE, ORCHESTRATOR_OWNER_ROLE);
-
-        // Set up MANAGER role structure:
-        // -> set OWNER as admin of DEFAULT_ADMIN_ROLE
-        _setRoleAdmin(ORCHESTRATOR_MANAGER_ROLE, ORCHESTRATOR_OWNER_ROLE);
-        // grant MANAGER Role to specified address
-        _grantRole(ORCHESTRATOR_MANAGER_ROLE, initialManager);
 
         // If there is no initial owner specfied or the initial owner is the same as the deployer
 
@@ -274,11 +266,6 @@ contract AUT_Roles_v1 is
     /// @inheritdoc IAuthorizer_v1
     function getOwnerRole() public pure returns (bytes32) {
         return ORCHESTRATOR_OWNER_ROLE;
-    }
-
-    /// @inheritdoc IAuthorizer_v1
-    function getManagerRole() public pure returns (bytes32) {
-        return ORCHESTRATOR_MANAGER_ROLE;
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -104,7 +104,6 @@ contract AUT_Roles_v1 is
         // It is defined in the AccessControl contract and identified with bytes32("0x00")
         // Modules can opt out of this on a per-role basis by setting the admin role to "BURN_ADMIN_ROLE".
 
-
         // If there is no initial admin specfied or the initial admin is the same as the deployer
 
         if (initialAdmin != address(0)) {

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -83,13 +83,6 @@ abstract contract Module_v1 is
         _;
     }
 
-    /// @notice Modifier to guarantee function is only callable by either
-    ///         addresses authorized via Orchestrator_v1 or the Orchestrator_v1's manager.
-    modifier onlyOrchestratorOwnerOrManager() {
-        _checkOnlyOrchestratorOwnerOrManagerModifier();
-        _;
-    }
-
     /// @notice Modifier to guarantee function is only callable by addresses that hold a specific module-assigned role.
     modifier onlyModuleRole(bytes32 role) {
         _checkRoleModifier(
@@ -275,22 +268,6 @@ abstract contract Module_v1 is
     function _checkRoleModifier(bytes32 role, address addr) internal view {
         if (!__Module_orchestrator.authorizer().hasRole(role, addr)) {
             revert Module__CallerNotAuthorized(role, addr);
-        }
-    }
-
-    function _checkOnlyOrchestratorOwnerOrManagerModifier() internal view {
-        IAuthorizer_v1 authorizer = __Module_orchestrator.authorizer();
-
-        bytes32 ownerRole = authorizer.getOwnerRole();
-        bytes32 managerRole = authorizer.getManagerRole();
-
-        if (
-            authorizer.hasRole(ownerRole, _msgSender())
-                || authorizer.hasRole(managerRole, _msgSender())
-        ) {
-            return;
-        } else {
-            revert Module__CallerNotAuthorized(ownerRole, _msgSender());
         }
     }
 

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -188,7 +188,7 @@ contract LM_PC_RecurringPayments_v1 is
         address recipient
     )
         external
-        onlyOrchestratorOwnerOrManager
+        onlyOrchestratorOwner
         validAmount(amount)
         validStartEpoch(startEpoch)
         validRecipient(recipient)
@@ -220,7 +220,7 @@ contract LM_PC_RecurringPayments_v1 is
     /// @inheritdoc ILM_PC_RecurringPayments_v1
     function removeRecurringPayment(uint prevId, uint id)
         external
-        onlyOrchestratorOwnerOrManager
+        onlyOrchestratorOwner
     {
         //trigger to resolve the given Payment
         _triggerFor(id, _paymentList.getNextId(id));

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -194,7 +194,7 @@ contract LM_PC_Staking_v1 is
     /// @inheritdoc ILM_PC_Staking_v1
     function setRewards(uint amount, uint duration)
         external
-        onlyOrchestratorOwnerOrManager
+        onlyOrchestratorOwner
     {
         _setRewards(amount, duration);
     }

--- a/test/e2e/E2EModuleRegistry.sol
+++ b/test/e2e/E2EModuleRegistry.sol
@@ -206,7 +206,7 @@ contract E2EModuleRegistry is Test {
     IOrchestratorFactory_v1.ModuleConfig roleAuthorizerFactoryConfig =
     IOrchestratorFactory_v1.ModuleConfig(
         roleAuthorizerMetadata,
-        abi.encode(address(this), address(this))  
+        abi.encode(address(this))  
     );
     */
     function setUpRoleAuthorizer() internal {
@@ -248,7 +248,7 @@ contract E2EModuleRegistry is Test {
     IOrchestratorFactory_v1.ModuleConfig tokenRoleAuthorizerFactoryConfig =
     IOrchestratorFactory_v1.ModuleConfig(
         tokenRoleAuthorizerMetadata,
-        abi.encode(address(this), address(this))  
+        abi.encode(address(this))  
     ); 
     */
 

--- a/test/e2e/authorizer/RoleAuthorizerE2E.t.sol
+++ b/test/e2e/authorizer/RoleAuthorizerE2E.t.sol
@@ -27,7 +27,7 @@ contract RoleAuthorizerE2E is E2ETest {
 
     // E2E Test Variables
     address orchestratorOwner = makeAddr("orchestratorOwner");
-    address orchestratorManager = makeAddr("orchestratorManager");
+    address bountyVerifier = makeAddr("bountyVerifier");
     address bountySubmitter = makeAddr("bountySubmitter");
 
     function setUp() public override {
@@ -54,7 +54,7 @@ contract RoleAuthorizerE2E is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 
@@ -119,7 +119,7 @@ contract RoleAuthorizerE2E is E2ETest {
 
         // we authorize the manager to verify bounty claims
         bountyManager.grantModuleRole(
-            bountyManager.VERIFIER_ROLE(), address(orchestratorManager)
+            bountyManager.VERIFIER_ROLE(), bountyVerifier
         );
 
         // we authorize the bountySubmitter to submit bounty claims
@@ -129,13 +129,6 @@ contract RoleAuthorizerE2E is E2ETest {
 
         // Since we deploy the orchestrator, with address(this) as owner and manager for easier setup,
         // we now assign them to two external addresses. In production these will be directly set on deployment.
-
-        // we grant manager role to managerAddress
-        bytes32 managerRole = authorizer.getManagerRole();
-        authorizer.grantRole(managerRole, address(orchestratorManager));
-        authorizer.renounceRole(managerRole, address(this));
-        assertTrue(authorizer.hasRole(managerRole, orchestratorManager));
-        assertEq(authorizer.getRoleMemberCount(managerRole), 1);
 
         //we grant owner role to ownerAddress
         bytes32 ownerRole = authorizer.getOwnerRole();
@@ -204,7 +197,7 @@ contract RoleAuthorizerE2E is E2ETest {
         //--------------------------------------------------------------------------------
         // Manager verifies bounty claim
         //--------------------------------------------------------------------------------
-        vm.prank(orchestratorManager);
+        vm.prank(bountyVerifier);
         bountyManager.verifyClaim(claimId, contribs);
     }
 }

--- a/test/e2e/authorizer/TokenGatedRoleAuthorizerE2E.t.sol
+++ b/test/e2e/authorizer/TokenGatedRoleAuthorizerE2E.t.sol
@@ -24,7 +24,7 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
 
     // E2E Test Variables
     address orchestratorOwner = makeAddr("orchestratorOwner");
-    address orchestratorManager = makeAddr("orchestratorManager");
+    address bountyVerifier = makeAddr("bountyVerifier");
     address bountySubmitter = makeAddr("bountySubmitter");
 
     ERC20Mock gatingToken = new ERC20Mock("Gating Token", "GATOR");
@@ -53,8 +53,7 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
         setUpTokenGatedRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                tokenRoleAuthorizerMetadata,
-                abi.encode(address(this), address(this))
+                tokenRoleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 
@@ -137,7 +136,7 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
             authorizer.setThreshold(verifierRoleId, address(gatingToken), 50);
 
             // We mint 51 tokens to the orchestrator manager so they can verify bounties
-            gatingToken.mint(orchestratorManager, 51);
+            gatingToken.mint(bountyVerifier, 51);
 
             // Make the CLAIM_ADMIN_ROLE token-gated by GATOR token and set the threshold
             bytes32 claimRoleId = authorizer.generateRoleId(
@@ -181,7 +180,7 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
 
         // others can't add it
         vm.expectRevert();
-        vm.prank(orchestratorManager);
+        vm.prank(bountyVerifier);
         bountyManager.addBounty(100e18, 500e18, "This is a test bounty");
 
         vm.expectRevert();
@@ -215,7 +214,7 @@ contract TokenGatedRoleAuthorizerE2E is E2ETest {
         //--------------------------------------------------------------------------------
         // Manager verifies bounty claim
         //--------------------------------------------------------------------------------
-        vm.prank(orchestratorManager);
+        vm.prank(bountyVerifier);
         bountyManager.verifyClaim(claimId, contribs);
 
         // the worker can't verifiy it

--- a/test/e2e/authorizer/extensions/VotingRoleManagerE2E.t.sol
+++ b/test/e2e/authorizer/extensions/VotingRoleManagerE2E.t.sol
@@ -54,8 +54,7 @@ contract VotingRoleManagerE2E is E2ETest {
         setUpTokenGatedRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                tokenRoleAuthorizerMetadata,
-                abi.encode(address(this), address(this))
+                tokenRoleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/factory/InverterBeaconE2E.t.sol
+++ b/test/e2e/factory/InverterBeaconE2E.t.sol
@@ -73,8 +73,7 @@ contract InverterBeaconE2E is E2ETest {
         setUpTokenGatedRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                tokenRoleAuthorizerMetadata,
-                abi.encode(address(this), address(this))
+                tokenRoleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/fundingManager/BondingCurveFundingManagerE2E.sol
+++ b/test/e2e/fundingManager/BondingCurveFundingManagerE2E.sol
@@ -90,7 +90,7 @@ contract BondingCurveFundingManagerE2E is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/fundingManager/RebasingFundingManagerE2E.sol
+++ b/test/e2e/fundingManager/RebasingFundingManagerE2E.sol
@@ -51,7 +51,7 @@ contract RebasingFundingManagerE2E is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/logicModules/BountyManagerE2E.t.sol
+++ b/test/e2e/logicModules/BountyManagerE2E.t.sol
@@ -56,7 +56,7 @@ contract BountyManagerE2E is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
+++ b/test/e2e/logicModules/KPIRewarderLifecycle.t.sol
@@ -166,7 +166,7 @@ contract LM_PC_KPIRewarder_v1Lifecycle is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/logicModules/RecurringPaymentManagerE2E.t.sol
+++ b/test/e2e/logicModules/RecurringPaymentManagerE2E.t.sol
@@ -69,7 +69,7 @@ contract RecurringPaymentManagerE2E is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/logicModules/StakingManagerLifecycle.t.sol
+++ b/test/e2e/logicModules/StakingManagerLifecycle.t.sol
@@ -89,7 +89,7 @@ contract LM_PC_Staking_v1Lifecycle is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/orchestrator_and_structural/OrchestratorE2E.sol
+++ b/test/e2e/orchestrator_and_structural/OrchestratorE2E.sol
@@ -58,7 +58,7 @@ contract OrchestratorE2E is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/e2e/paymentProcessor/StreamingPaymentProcessorE2E.sol
+++ b/test/e2e/paymentProcessor/StreamingPaymentProcessorE2E.sol
@@ -66,7 +66,7 @@ contract StreamingPaymentProcessorE2E is E2ETest {
         setUpRoleAuthorizer();
         moduleConfigurations.push(
             IOrchestratorFactory_v1.ModuleConfig(
-                roleAuthorizerMetadata, abi.encode(address(this), address(this))
+                roleAuthorizerMetadata, abi.encode(address(this))
             )
         );
 

--- a/test/modules/authorizer/role/AUT_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_Roles_v1.t.sol
@@ -121,19 +121,11 @@ contract AUT_RolesV1Test is Test {
         );
 
         address initialAuth = ALBA;
-        address initialManager = address(this);
 
         _authorizer.init(
-            IOrchestrator_v1(_orchestrator),
-            _METADATA,
-            abi.encode(initialAuth, initialManager)
+            IOrchestrator_v1(_orchestrator), _METADATA, abi.encode(initialAuth)
         );
 
-        //console.log(_authorizer.hasRole(_authorizer.getManagerRole(), initialManager));
-        assertEq(
-            _authorizer.hasRole(_authorizer.getManagerRole(), address(this)),
-            true
-        );
         //console.log(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA));
         assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
         //console.log(_authorizer.hasRole(_authorizer.getOwnerRole(), address(this)));
@@ -232,13 +224,12 @@ contract AUT_RolesV1Test is Test {
         );
 
         address initialOwner = address(this);
-        address initialManager = address(this);
 
         vm.expectRevert();
         _authorizer.init(
             IOrchestrator_v1(newOrchestrator),
             _METADATA,
-            abi.encode(initialOwner, initialManager)
+            abi.encode(initialOwner)
         );
         assertEq(_authorizer.hasRole("0x01", address(this)), false);
         assertEq(address(_authorizer.orchestrator()), address(_orchestrator));
@@ -329,133 +320,6 @@ contract AUT_RolesV1Test is Test {
             _authorizer.getRoleMemberCount(_authorizer.getOwnerRole()),
             amountAuth
         );
-    }
-
-    function testGrantManagerRole(address[] memory newAuthorized) public {
-        // Here we test adding to a role with OWNER as admin
-
-        bytes32 managerRole = _authorizer.getManagerRole();
-        uint amountManagers = _authorizer.getRoleMemberCount(managerRole);
-
-        _validateAuthorizedList(newAuthorized);
-
-        vm.startPrank(address(ALBA));
-        for (uint i; i < newAuthorized.length; ++i) {
-            vm.expectEmit(true, true, true, true);
-            emit RoleGranted(managerRole, newAuthorized[i], address(ALBA));
-            _authorizer.grantRole(managerRole, newAuthorized[i]);
-        }
-        vm.stopPrank();
-
-        for (uint i; i < newAuthorized.length; ++i) {
-            assertEq(_authorizer.hasRole(managerRole, newAuthorized[i]), true);
-        }
-        assertEq(
-            _authorizer.getRoleMemberCount(managerRole),
-            (amountManagers + newAuthorized.length)
-        );
-    }
-
-    function testGrantManagerRoleFailsIfNotOwner(address[] memory newAuthorized)
-        public
-    {
-        // Here we test adding to a role that has OWNER as admin while not being OWNER
-        bytes32 managerRole = _authorizer.getManagerRole();
-
-        vm.startPrank(address(ALBA));
-        _authorizer.grantRole(managerRole, BOB); //Meet your new Manager
-        vm.stopPrank();
-
-        //assertEq(_authorizer.hasRole(address(_orchestrator), 1, BOB), true);
-        assertEq(_authorizer.hasRole(managerRole, BOB), true);
-
-        uint amountManagers = _authorizer.getRoleMemberCount(managerRole);
-
-        _validateAuthorizedList(newAuthorized);
-
-        vm.startPrank(address(BOB));
-        for (uint i; i < newAuthorized.length; ++i) {
-            vm.expectRevert(); // Just a general revert since AccesControl doesn't have error types
-            _authorizer.grantRole(managerRole, newAuthorized[i]);
-        }
-        vm.stopPrank();
-
-        for (uint i; i < newAuthorized.length; ++i) {
-            assertEq(_authorizer.hasRole(managerRole, newAuthorized[i]), false);
-        }
-        assertEq(_authorizer.getRoleMemberCount(managerRole), amountManagers);
-    }
-
-    function testRevokeManagerRole(address[] memory newAuthorized) public {
-        // Here we test adding to a role with OWNER as admin
-
-        bytes32 managerRole = _authorizer.getManagerRole();
-        uint amountManagers = _authorizer.getRoleMemberCount(managerRole);
-
-        _validateAuthorizedList(newAuthorized);
-
-        vm.startPrank(address(ALBA));
-        for (uint i; i < newAuthorized.length; ++i) {
-            _authorizer.grantRole(managerRole, newAuthorized[i]);
-        }
-        vm.stopPrank();
-
-        for (uint i; i < newAuthorized.length; ++i) {
-            assertEq(_authorizer.hasRole(managerRole, newAuthorized[i]), true);
-        }
-        assertEq(
-            _authorizer.getRoleMemberCount(managerRole),
-            (amountManagers + newAuthorized.length)
-        );
-
-        // Now we remove them all
-
-        vm.startPrank(address(ALBA));
-        for (uint i; i < newAuthorized.length; ++i) {
-            vm.expectEmit(true, true, true, true);
-            emit RoleRevoked(managerRole, newAuthorized[i], address(ALBA));
-
-            _authorizer.revokeRole(managerRole, newAuthorized[i]);
-        }
-        vm.stopPrank();
-
-        for (uint i; i < newAuthorized.length; ++i) {
-            /* assertEq(
-                _authorizer.hasRole(address(_orchestrator), 1, newAuthorized[i]),
-                false
-            );*/
-            assertEq(_authorizer.hasRole(managerRole, newAuthorized[i]), false);
-        }
-        assertEq(_authorizer.getRoleMemberCount(managerRole), amountManagers);
-    }
-
-    function testRevokeManagerRoleFailsIfNotOwner(
-        address[] memory newAuthorized
-    ) public {
-        // Here we test adding to a role that has OWNER as admin while not being OWNER
-        bytes32 managerRole = _authorizer.getManagerRole();
-
-        vm.startPrank(address(ALBA));
-        _authorizer.grantRole(managerRole, BOB); //Meet your new Manager
-        vm.stopPrank();
-
-        assertEq(_authorizer.hasRole(managerRole, BOB), true);
-
-        uint amountManagers = _authorizer.getRoleMemberCount(managerRole);
-
-        _validateAuthorizedList(newAuthorized);
-
-        vm.startPrank(address(BOB));
-        for (uint i; i < newAuthorized.length; ++i) {
-            vm.expectRevert(); // Just a general revert since AccesControl doesn't have error types
-            _authorizer.revokeRole(managerRole, newAuthorized[i]);
-        }
-        vm.stopPrank();
-
-        for (uint i; i < newAuthorized.length; ++i) {
-            assertEq(_authorizer.hasRole(managerRole, newAuthorized[i]), false);
-        }
-        assertEq(_authorizer.getRoleMemberCount(managerRole), amountManagers);
     }
 
     // Test grantRoleFromModule

--- a/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
@@ -61,16 +61,9 @@ contract AUT_TokenGated_RolesV1Test is AUT_RolesV1Test {
         );
 
         address initialAuth = ALBA;
-        address initialManager = address(this);
 
         _authorizer.init(
-            IOrchestrator_v1(_orchestrator),
-            _METADATA,
-            abi.encode(initialAuth, initialManager)
-        );
-        assertEq(
-            _authorizer.hasRole(_authorizer.getManagerRole(), address(this)),
-            true
+            IOrchestrator_v1(_orchestrator), _METADATA, abi.encode(initialAuth)
         );
         assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
         assertEq(
@@ -147,16 +140,9 @@ contract TokenGatedAUT_RoleV1Test is Test {
         );
 
         address initialAuth = ALBA;
-        address initialManager = address(this);
 
         _authorizer.init(
-            IOrchestrator_v1(_orchestrator),
-            _METADATA,
-            abi.encode(initialAuth, initialManager)
-        );
-        assertEq(
-            _authorizer.hasRole(_authorizer.getManagerRole(), address(this)),
-            true
+            IOrchestrator_v1(_orchestrator), _METADATA, abi.encode(initialAuth)
         );
         assertEq(_authorizer.hasRole(_authorizer.getOwnerRole(), ALBA), true);
         assertEq(

--- a/test/modules/logicModule/LM_PC_Staking_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_Staking_v1.t.sol
@@ -468,7 +468,7 @@ contract LM_PC_Staking_v1Test is ModuleTest {
     }
 
     function testSetRewardsModifierInPosition() public {
-        //onlyOrchestratorOwnerOrManager
+        //onlyOrchestratorOwner
         vm.expectRevert(
             abi.encodeWithSelector(
                 IModule_v1.Module__CallerNotAuthorized.selector,

--- a/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
@@ -241,7 +241,7 @@ contract LM_PC_RecurringV1Test is ModuleTest {
         //Warp to a reasonable time
         vm.warp(2 weeks);
 
-        //onlyOrchestratorOwnerOrManager
+        //onlyOrchestratorOwner
         vm.expectRevert(
             abi.encodeWithSelector(
                 IModule_v1.Module__CallerNotAuthorized.selector,
@@ -368,7 +368,7 @@ contract LM_PC_RecurringV1Test is ModuleTest {
             _orchestrator, _METADATA, abi.encode(1 weeks)
         );
 
-        //onlyOrchestratorOwnerOrManager
+        //onlyOrchestratorOwner
         vm.expectRevert(
             abi.encodeWithSelector(
                 IModule_v1.Module__CallerNotAuthorized.selector,

--- a/test/utils/mocks/modules/AuthorizerV1Mock.sol
+++ b/test/utils/mocks/modules/AuthorizerV1Mock.sol
@@ -138,10 +138,6 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
         return "0x01";
     }
 
-    function getManagerRole() external pure returns (bytes32) {
-        return "0x02";
-    }
-
     function grantGlobalRole(bytes32 role, address target) external {
         bytes32 roleID = generateRoleId(address(orchestrator()), role);
         grantRole(roleID, target);


### PR DESCRIPTION
The Orchestrator Manager Role never found a real usecase. This PR removes it so streamline the code. Modules are still capable of defining a role that acts a manager on their own if necessary.

## What has been done
- Removed orchestratorManager Role and corresponding functions from AUT_Roles
- Replaced instances of onlyOrchestratorOwnerOrManager with onlyOrchestratorOwner
-  Updated tests and scripts

**NOTE** That this PR kind of goes hand in hand with #526 . We should merge one of the two first and then rebase the other with the changes.

Also **NOTE** that this PR leaves the term "owner" when present in the scripts. It will be removed in a separate Script PR when we have some time.