### PR TITLE
[SC-677] Bug(139):  Add validation to setting virtual issuance supply in FM_BC_Bancor

### DIFF
--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -507,4 +507,19 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
                 Module__FM_BC_Bancor_Redeeming_VirtualSupply__InvalidReserveRatio();
         }
     }
+
+    /// @dev    Internal function to directly set the virtual issuance supply to a new value.
+    ///         Virtual supply cannot be zero, or result in rounded down being zero when conversion
+    ///         is done for use in the Bancor Formulat
+    /// @param  _virtualSupply The new value to set for the virtual issuance supply.
+    function _setVirtualIssuanceSupply(uint _virtualSupply) internal override {
+        // Check if virtual supply is big enough to ensure compatibility with relative issuance
+        // token decimal and conversion to 18 decimals done in FM_BC_Tools._convertAmountToRequiredDecimal()
+        // so it will not result in a round down 0 value
+        if (_virtualSupply < 10 ** (issuanceTokenDecimals - 18)) {
+            revert Module__VirtualIssuanceSupplyBase__VirtualSupplyCannotBeZero(
+            );
+        }
+        super._setVirtualIssuanceSupply(_virtualSupply);
+    }
 }

--- a/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/abstracts/VirtualIssuanceSupplyBase_v1.sol
@@ -103,7 +103,7 @@ abstract contract VirtualIssuanceSupplyBase_v1 is
 
     /// @dev Internal function to directly set the virtual issuance supply to a new value.
     /// @param _virtualSupply The new value to set for the virtual issuance supply.
-    function _setVirtualIssuanceSupply(uint _virtualSupply) internal {
+    function _setVirtualIssuanceSupply(uint _virtualSupply) internal virtual {
         if (_virtualSupply == 0) {
             revert Module__VirtualIssuanceSupplyBase__VirtualSupplyCannotBeZero(
             );

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -163,9 +163,9 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Tests is
     uint internal constant MAX_SUPPLY = type(uint).max;
 
     uint internal constant INITIAL_ISSUANCE_SUPPLY = 1;
-    uint internal constant INITIAL_COLLATERAL_SUPPLY = 1;
-    uint32 internal constant RESERVE_RATIO_FOR_BUYING = 200_000;
-    uint32 internal constant RESERVE_RATIO_FOR_SELLING = 200_000;
+    uint internal constant INITIAL_COLLATERAL_SUPPLY = 3;
+    uint32 internal constant RESERVE_RATIO_FOR_BUYING = 333_333;
+    uint32 internal constant RESERVE_RATIO_FOR_SELLING = 333_333;
     uint internal constant BUY_FEE = 0;
     uint internal constant SELL_FEE = 0;
     bool internal constant BUY_IS_OPEN = true;

--- a/test/modules/fundingManager/bondingCurve/utils/mocks/FM_BC_Bancor_Redeeming_VirtualSupplyV1Mock.sol
+++ b/test/modules/fundingManager/bondingCurve/utils/mocks/FM_BC_Bancor_Redeeming_VirtualSupplyV1Mock.sol
@@ -55,6 +55,10 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Mock is
         _setIssuanceToken(_newIssuanceToken);
     }
 
+    function call_setVirtualIssuanceSupply(uint _newSupply) external {
+        _setVirtualIssuanceSupply(_newSupply);
+    }
+
     function call_convertAmountToRequiredDecimal(
         uint _amount,
         uint8 _tokenDecimals,

--- a/test/modules/fundingManager/bondingCurve/utils/mocks/FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Mock.sol
+++ b/test/modules/fundingManager/bondingCurve/utils/mocks/FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Mock.sol
@@ -95,6 +95,10 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1Mock is
         return decimalConvertedVirtualIssuanceSupply;
     }
 
+    function call_setVirtualIssuanceSupply(uint _newSupply) external {
+        _setVirtualIssuanceSupply(_newSupply);
+    }
+
     // Note: this function returns the virtual collateral supply in the same format it will be fed to the Bancor formula
     function call_getFormulaVirtualCollateralSupply()
         external


### PR DESCRIPTION
## What has been done?
- The internal `_setVirtualSupply()`  function has been made virtual to be extended with functionalities in the implementation
- The extended function validates that the to-be-set supply after conversion does not result in 0
- Adapted test