### PR TITLE
Chore: Emit human readable metadata in `ModuleCreated` event

### DIFF
--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -178,7 +178,7 @@ contract ModuleFactory_v1 is
         _orchestratorOfProxy[proxy] = address(orchestrator);
 
         emit ModuleCreated(
-            address(orchestrator), proxy, LibMetadata.identifier(metadata)
+            address(orchestrator), proxy, metadata
         );
 
         return proxy;

--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -177,9 +177,7 @@ contract ModuleFactory_v1 is
 
         _orchestratorOfProxy[proxy] = address(orchestrator);
 
-        emit ModuleCreated(
-            address(orchestrator), proxy, metadata
-        );
+        emit ModuleCreated(address(orchestrator), proxy, metadata);
 
         return proxy;
     }

--- a/src/factories/interfaces/IModuleFactory_v1.sol
+++ b/src/factories/interfaces/IModuleFactory_v1.sol
@@ -43,7 +43,9 @@ interface IModuleFactory_v1 {
     /// @param module The created module instance.
     /// @param metadata The registered Metadata
     event ModuleCreated(
-        address indexed orchestrator, address indexed module, IModule_v1.Metadata metadata
+        address indexed orchestrator,
+        address indexed module,
+        IModule_v1.Metadata metadata
     );
 
     //--------------------------------------------------------------------------

--- a/src/factories/interfaces/IModuleFactory_v1.sol
+++ b/src/factories/interfaces/IModuleFactory_v1.sol
@@ -41,9 +41,9 @@ interface IModuleFactory_v1 {
     /// @notice Event emitted when new module created for a orchestrator_v1.
     /// @param orchestrator The corresponding orchestrator.
     /// @param module The created module instance.
-    /// @param identifier The module's identifier.
+    /// @param metadata The registered Metadata
     event ModuleCreated(
-        address indexed orchestrator, address indexed module, bytes32 identifier
+        address indexed orchestrator, address indexed module, IModule_v1.Metadata metadata
     );
 
     //--------------------------------------------------------------------------

--- a/src/modules/base/IModule_v1.sol
+++ b/src/modules/base/IModule_v1.sol
@@ -19,13 +19,8 @@ interface IModule_v1 {
     /// @notice Module has been initialized.
     /// @param parentOrchestrator The address of the orchestrator the module is linked to.
     /// @param moduleTitle The title of the module.
-    /// @param majorVersion The major version of the module.
-    /// @param minorVersion The minor version of the module.
     event ModuleInitialized(
-        address indexed parentOrchestrator,
-        string indexed moduleTitle,
-        uint majorVersion,
-        uint minorVersion
+        address indexed parentOrchestrator, string indexed moduleTitle
     );
 
     //--------------------------------------------------------------------------

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -156,12 +156,7 @@ abstract contract Module_v1 is
         }
         __Module_metadata = metadata;
 
-        emit ModuleInitialized(
-            address(orchestrator_),
-            metadata.title,
-            metadata.majorVersion,
-            metadata.minorVersion
-        );
+        emit ModuleInitialized(address(orchestrator_), metadata.title);
     }
 
     //--------------------------------------------------------------------------

--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -58,7 +58,9 @@ contract ModuleFactoryV1Test is Test {
 
     /// @notice Event emitted when new module created for a orchestrator.
     event ModuleCreated(
-        address indexed orchestrator, address indexed module, IModule_v1.Metadata metadata
+        address indexed orchestrator,
+        address indexed module,
+        IModule_v1.Metadata metadata
     );
 
     // Constants
@@ -270,9 +272,7 @@ contract ModuleFactoryV1Test is Test {
         vm.expectEmit(true, false, false, false);
 
         // We emit the event we expect to see.
-        emit ModuleCreated(
-            orchestrator, address(0), metadata
-        );
+        emit ModuleCreated(orchestrator, address(0), metadata);
 
         // Create new module instance.
         IModule_v1 newModule = IModule_v1(

--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -58,7 +58,7 @@ contract ModuleFactoryV1Test is Test {
 
     /// @notice Event emitted when new module created for a orchestrator.
     event ModuleCreated(
-        address indexed orchestrator, address indexed module, bytes32 identifier
+        address indexed orchestrator, address indexed module, IModule_v1.Metadata metadata
     );
 
     // Constants
@@ -271,7 +271,7 @@ contract ModuleFactoryV1Test is Test {
 
         // We emit the event we expect to see.
         emit ModuleCreated(
-            orchestrator, address(0), LibMetadata.identifier(metadata)
+            orchestrator, address(0), metadata
         );
 
         // Create new module instance.

--- a/test/modules/base/Module_v1.t.sol
+++ b/test/modules/base/Module_v1.t.sol
@@ -49,13 +49,8 @@ contract ModuleBaseV1Test is ModuleTest {
     /// @notice Module has been initialized.
     /// @param parentOrchestrator The address of the orchestrator the module is linked to.
     /// @param moduleTitle The title of the module.
-    /// @param majorVersion The major version of the module.
-    /// @param minorVersion The minor version of the module.
     event ModuleInitialized(
-        address indexed parentOrchestrator,
-        string indexed moduleTitle,
-        uint majorVersion,
-        uint minorVersion
+        address indexed parentOrchestrator, string indexed moduleTitle
     );
 
     function setUp() public {
@@ -65,9 +60,7 @@ contract ModuleBaseV1Test is ModuleTest {
         _setUpOrchestrator(module);
 
         vm.expectEmit(true, true, true, false);
-        emit ModuleInitialized(
-            address(_orchestrator), _TITLE, _MAJOR_VERSION, _MINOR_VERSION
-        );
+        emit ModuleInitialized(address(_orchestrator), _TITLE);
 
         module.init(_orchestrator, _METADATA, _CONFIGDATA);
     }


### PR DESCRIPTION
### Before PR
* the `ModuleCreated` event is emitted by the ModuleFactory
* it includes a module identifier as bytes32 value
* this is not practical for indexing newly created modules, because it makes it hard to categorize newly created modules (is it an authorizer? is it a bonding curve?)

### After PR
* instead of emitting the module identifier as bytes32, the human-readable metadata is emitted so that an indexer knows upon module creation what type the module is