### PR TITLE
[SC-644] Bug(74): OptimisticOracleIntegrator doesn't add OptimisticOracleV3CallbackRecipientInterface interfaceId as supported interfaces

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -48,10 +48,11 @@ contract LM_PC_KPIRewarder_v1 is
         public
         view
         virtual
-        override(LM_PC_Staking_v1, Module_v1)
+        override(OptimisticOracleIntegrator, LM_PC_Staking_v1)
         returns (bool)
     {
         return interfaceId == type(ILM_PC_KPIRewarder_v1).interfaceId
+            || interfaceId == type(ILM_PC_Staking_v1).interfaceId
             || super.supportsInterface(interfaceId);
     }
 

--- a/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
+++ b/src/modules/logicModule/abstracts/oracleIntegrations/UMA_OptimisticOracleV3/OptimisticOracleIntegrator.sol
@@ -39,6 +39,19 @@ abstract contract OptimisticOracleIntegrator is
 {
     using SafeERC20 for IERC20;
 
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(Module_v1)
+        returns (bool)
+    {
+        return interfaceId == type(IOptimisticOracleIntegrator).interfaceId
+            || interfaceId
+                == type(OptimisticOracleV3CallbackRecipientInterface).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
     //==========================================================================
     // Constants
 

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -27,7 +27,8 @@ import {
     LM_PC_KPIRewarder_v1,
     ILM_PC_KPIRewarder_v1,
     IOptimisticOracleIntegrator,
-    ILM_PC_Staking_v1
+    ILM_PC_Staking_v1,
+    OptimisticOracleV3CallbackRecipientInterface
 } from "src/modules/logicModule/LM_PC_KPIRewarder_v1.sol";
 
 import {
@@ -220,6 +221,18 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
     function testReinitFails() public override(ModuleTest) {
         vm.expectRevert(OZErrors.Initializable__InvalidInitialization);
         kpiManager.init(_orchestrator, _METADATA, bytes(""));
+    }
+
+    function test_InterfaceInheritanceTree() public {
+        kpiManager.supportsInterface(type(ILM_PC_KPIRewarder_v1).interfaceId);
+        kpiManager.supportsInterface(type(ILM_PC_Staking_v1).interfaceId);
+        kpiManager.supportsInterface(
+            type(IOptimisticOracleIntegrator).interfaceId
+        );
+        kpiManager.supportsInterface(
+            type(OptimisticOracleV3CallbackRecipientInterface).interfaceId
+        );
+        kpiManager.supportsInterface(type(IModule_v1).interfaceId);
     }
 
     // Creates  dummy incontinuous KPI with 3 tranches, a max value of 300 and 300e18 tokens for rewards


### PR DESCRIPTION
This PR adds interface checks for `IOptimisticOracleIntegrator` and `OptimisticOracleV3CallbackRecipientInterface`, plus an additional test. 

