### PR TITLE
[SC-690] feat: remove transferOrchestratorToken override

### DIFF
--- a/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -87,19 +87,4 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1 is
             Module__FM_BC_Restricted_Bancor_Redeeming_VirtualSupply__FeatureDeactivated(
         );
     }
-
-    //--------------------------------------------------------------------------
-    // OnlyOrchestrator Functions
-
-    /// @notice Transfer a specified amount of Tokens to a designated receiver address. Deactivated in this implementation.
-    function transferOrchestratorToken(address, uint)
-        external
-        view
-        override
-        onlyOrchestrator
-    {
-        revert
-            Module__FM_BC_Restricted_Bancor_Redeeming_VirtualSupply__FeatureDeactivated(
-        );
-    }
 }

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -104,33 +104,6 @@ contract FM_BC_Restricted_Bancor_Redeeming_VirtualSupplyV1UpstreamTests is
     }
 
     // Override to test deactivation
-    function testTransferOrchestratorToken(address to, uint amount)
-        public
-        override
-    {
-        vm.assume(to != address(0) && to != address(bondingCurveFundingManager));
-
-        _token.mint(address(bondingCurveFundingManager), amount);
-
-        vm.startPrank(address(_orchestrator));
-        {
-            vm.expectRevert(
-                abi.encodeWithSelector(
-                    FM_BC_Restricted_Bancor_Redeeming_VirtualSupply_v1
-                        .Module__FM_BC_Restricted_Bancor_Redeeming_VirtualSupply__FeatureDeactivated
-                        .selector
-                )
-            );
-
-            bondingCurveFundingManager.transferOrchestratorToken(to, amount);
-        }
-        vm.stopPrank();
-
-        assertEq(_token.balanceOf(to), 0);
-        assertEq(_token.balanceOf(address(bondingCurveFundingManager)), amount);
-    }
-
-    // Override to test deactivation
     function testMintIssuanceTokenTo(uint amount) public override {
         assertEq(issuanceToken.balanceOf(non_admin_address), 0);
 


### PR DESCRIPTION
## What has been done?
- We have restructured the flow of how tokens get drawn from the FM. This resulted in that there is no need for the restriction anymore
## Issue and PR
- https://linear.app/inverter/issue/SC-631/bug50-any-module-can-drain-the-fundingmanager-of-all-funding-tokens
- https://github.com/InverterNetwork/contracts/pull/562