### PR TITLE
[SC-675] (Bug135) activepaymentreceivers does not need to be read from storage

### DIFF
--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -451,7 +451,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     ) internal view returns (uint) {
         address[] memory receiverSearchArray = activePaymentReceivers[client];
 
-        uint length = activePaymentReceivers[client].length;
+        uint length = receiverSearchArray.length;
         for (uint i; i < length;) {
             if (receiverSearchArray[i] == paymentReceiver) {
                 return i;


### PR DESCRIPTION
Changed read from storage to cached variable to save gas