### PR TITLE
[SC-667] (Bug119) reentrancy vulnerability in Vulnerability in PP_Streaming_v1::claimPreviouslyUnclaimable Results in Temporary Lock of Fund

### DIFF
--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -801,13 +801,13 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
         // As all of the stream ids should have been claimed we can delete the stream id array
         delete unclaimableStreams[client][token][sender];
 
+        // Make sure to let paymentClient know that amount doesnt have to be stored anymore
+        IERC20PaymentClientBase_v1(client).amountPaid(address(token), amount);
+
         // Call has to succeed otherwise no state change
         IERC20(token).safeTransferFrom(client, paymentReceiver, amount);
 
         emit TokensReleased(paymentReceiver, address(token), amount);
-
-        // Make sure to let paymentClient know that amount doesnt have to be stored anymore
-        IERC20PaymentClientBase_v1(client).amountPaid(address(token), amount);
     }
 
     /// @notice Virtual implementation of the stream formula.


### PR DESCRIPTION
## What has been done
The calll to update PaymentClient.amountPaid() now happens before the transfer.