### PR TITLE
[SC-641] (Bug 65) LM_PC_KPIRewarder_v1 can be set as a callback address to another assertion in order to set assertionPending = false

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -350,6 +350,12 @@ contract LM_PC_KPIRewarder_v1 is
         bytes32 assertionId,
         bool assertedTruthfully
     ) public override {
+        // Ensure the assertionId exists in this contract (since malicious assertions could callback this contract)
+        if (assertionData[assertionId].dataId == bytes32(0x0)) {
+            revert
+                Module__LM_PC_KPIRewarder_v1__CallbackFromNonexistentAssertionId();
+        }
+
         // First, we perform checks and state management on the parent function.
         super.assertionResolvedCallback(assertionId, assertedTruthfully);
 

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -58,6 +58,8 @@ interface ILM_PC_KPIRewarder_v1 {
     /// @notice An assertion can only by posted if the preceding one is resolved.
     error Module__LM_PC_KPIRewarder_v1__UnresolvedAssertionExists();
 
+    /// @notice Callback received references non existent assertionId
+    error Module__LM_PC_KPIRewarder_v1__CallbackFromNonexistentAssertionId();
     //--------------------------------------------------------------------------
     // Events
 


### PR DESCRIPTION
## What has been done
- assertionResolvedCallback() now reverts if the assertionId doesn't exist locally.
- Added check to test suite

**Note:** I thought about including the check in the OptimisiticOracleIntegrator instead of the KPIRewarder, but ended up deciding against it, since the vulnerability arises from changing the state of assertionResolved. One could imagine an OptimisiticOracleIntegrator Module that is actually designed to receive callbacks it didn't create itself.