### PR TITLE
DO NOT MERGE [SC-645] (Bug 75) LM_PC_KPIRewarder_v1: DoS vector if bond token has a blocklist and disputer set disputer address to a blocked address

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -359,12 +359,12 @@ contract LM_PC_KPIRewarder_v1 is
             oo.getAssertion(assertionId).expirationTime;
 
         if (block.timestamp < assertionExpirationTime) {
-            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck(assertionId);
         }
 
         try oo.settleAssertion(assertionId) {
             // If the assertion can be settled, it doesn't qualify as stuck and we revert
-            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck(assertionId);
         } catch {
             delete assertionConfig[assertionId];
             delete assertionData[assertionId];

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -292,7 +292,7 @@ contract LM_PC_Staking_v1 is
     ///@dev direct distribution of earned rewards via the payment processor
     function _distributeRewards(address recipient) internal {
         // Check what recipient has earned
-        uint amount = _earned(recipient, rewardValue);
+        uint amount = rewards[recipient];
         // Set rewards to zero
         rewards[recipient] = 0;
 

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -64,7 +64,7 @@ interface ILM_PC_KPIRewarder_v1 {
     );
 
     /// @notice The assertion that is being removed was not stuck
-    error Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+    error Module__LM_PC_KPIRewarder_v1__AssertionNotStuck(bytes32 assertionId);
 
     //--------------------------------------------------------------------------
     // Events

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -58,6 +58,14 @@ interface ILM_PC_KPIRewarder_v1 {
     /// @notice An assertion can only by posted if the preceding one is resolved.
     error Module__LM_PC_KPIRewarder_v1__UnresolvedAssertionExists();
 
+    /// @notice Callback received references non existent assertionId
+    error Module__LM_PC_KPIRewarder_v1__NonExistentAssertionId(
+        bytes32 assertionId
+    );
+
+    /// @notice The assertion that is being removed was not stuck
+    error Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+
     //--------------------------------------------------------------------------
     // Events
 
@@ -86,6 +94,9 @@ interface ILM_PC_KPIRewarder_v1 {
 
     /// @notice Event emitted when funds for paying the bonding fee are deposited into the contract
     event FeeFundsDeposited(address indexed token, uint amount);
+
+    /// @notice Event emitted when a stuck assertion gets deleted
+    event DeletedStuckAssertion(bytes32 indexed assertionId);
 
     //--------------------------------------------------------------------------
     // Functions

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -451,7 +451,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     ) internal view returns (uint) {
         address[] memory receiverSearchArray = activePaymentReceivers[client];
 
-        uint length = activePaymentReceivers[client].length;
+        uint length = receiverSearchArray.length;
         for (uint i; i < length;) {
             if (receiverSearchArray[i] == paymentReceiver) {
                 return i;


### PR DESCRIPTION
**NOTE: There is something weird with the commits, I think it's because of the issue we had this morning. Will need review**


## What has been done
- Added a onlyAdmin `deleteStuckAssertion()` function that allows removal of reverting assertion settlements. This function deletes local storage of the faulty assertion as if it had been asserted False and resests `asertionPending`
- Created tests for the new function