### PR TITLE
[SC-645] (Bug 75) LM_PC_KPIRewarder_v1: DoS vector if bond token has a blocklist and disputer set disputer address to a blocked address

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -383,8 +383,9 @@ contract LM_PC_KPIRewarder_v1 is
     ) public override {
         // Ensure the assertionId exists in this contract (since malicious assertions could callback this contract)
         if (assertionData[assertionId].dataId == bytes32(0x0)) {
-            revert
-                Module__LM_PC_KPIRewarder_v1__CallbackFromNonexistentAssertionId();
+            revert Module__LM_PC_KPIRewarder_v1__NonExistentAssertionId(
+                assertionId
+            );
         }
 
         // First, we perform checks and state management on the parent function.

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -359,12 +359,12 @@ contract LM_PC_KPIRewarder_v1 is
             oo.getAssertion(assertionId).expirationTime;
 
         if (block.timestamp < assertionExpirationTime) {
-            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck(assertionId);
         }
 
         try oo.settleAssertion(assertionId) {
             // If the assertion can be settled, it doesn't qualify as stuck and we revert
-            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+            revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck(assertionId);
         } catch {
             delete assertionConfig[assertionId];
             delete assertionData[assertionId];

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -353,12 +353,10 @@ contract LM_PC_KPIRewarder_v1 is
             );
         }
 
-        // TODO make sure that the assertion has expired before trying to see if it settles (snippet below not working))
-
         uint assertionExpirationTime =
             oo.getAssertion(assertionId).expirationTime;
 
-        if (block.timestamp < assertionExpirationTime) {
+        if (block.timestamp <= assertionExpirationTime) {
             revert Module__LM_PC_KPIRewarder_v1__AssertionNotStuck(assertionId);
         }
 

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -59,7 +59,13 @@ interface ILM_PC_KPIRewarder_v1 {
     error Module__LM_PC_KPIRewarder_v1__UnresolvedAssertionExists();
 
     /// @notice Callback received references non existent assertionId
-    error Module__LM_PC_KPIRewarder_v1__CallbackFromNonexistentAssertionId();
+    error Module__LM_PC_KPIRewarder_v1__NonExistentAssertionId(
+        bytes32 assertionId
+    );
+
+    /// @notice The assertion that is being removed was not stuck
+    error Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+
     //--------------------------------------------------------------------------
     // Events
 
@@ -88,6 +94,9 @@ interface ILM_PC_KPIRewarder_v1 {
 
     /// @notice Event emitted when funds for paying the bonding fee are deposited into the contract
     event FeeFundsDeposited(address indexed token, uint amount);
+
+    /// @notice Event emitted when a stuck assertion gets deleted
+    event DeletedStuckAssertion(bytes32 indexed assertionId);
 
     //--------------------------------------------------------------------------
     // Functions

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -64,7 +64,7 @@ interface ILM_PC_KPIRewarder_v1 {
     );
 
     /// @notice The assertion that is being removed was not stuck
-    error Module__LM_PC_KPIRewarder_v1__AssertionNotStuck();
+    error Module__LM_PC_KPIRewarder_v1__AssertionNotStuck(bytes32 assertionId);
 
     //--------------------------------------------------------------------------
     // Events

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -101,6 +101,8 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
         address indexed recipient, address indexed token, uint amount
     );
 
+    event DeletedStuckAssertion(bytes32 indexed assertionId);
+
     //=========================================================================================
     // Setup
 
@@ -1334,6 +1336,8 @@ contract LM_PC_KPIRewarder_v1_dequeueTest is LM_PC_KPIRewarder_v1Test {
     testDeleteStuckAssertion
     ├── When the assertion isn't stored locally
     │    └── It should revert
+    |── When the assertion hasn't expired yet
+    │    └── It should revert
     ├── When the assertion CAN be resolved
     │    └── It should revert
     └── When the assertion CAN NOT be resolved
@@ -1362,6 +1366,37 @@ contract LM_PC_KPIRewarder_v1_deleteStuckAssertionTest is
         kpiManager.deleteStuckAssertion(assertionId);
     }
 
+    function test_RevertWhen_TheAssertionHasNotExpired(
+        address[] memory users,
+        uint[] memory amounts
+    ) external {
+        // it should revert
+
+        vm.assume(users.length > 1);
+
+        uint assertedIntermediateValue = 250;
+
+        bytes32 createdID;
+        uint totalStakedFunds;
+        (createdID, users, amounts, totalStakedFunds) =
+        setUpStateForAssertionResolution(
+            users, amounts, assertedIntermediateValue, true
+        );
+
+        // Assertion hasn't expired yet
+        vm.warp(block.timestamp + 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_KPIRewarder_v1
+                    .Module__LM_PC_KPIRewarder_v1__AssertionNotStuck
+                    .selector,
+                createdID
+            )
+        );
+        kpiManager.deleteStuckAssertion(createdID);
+    }
+
     function test_RevertWhen_TheAssertionCanBeResolved(
         address[] memory users,
         uint[] memory amounts
@@ -1379,18 +1414,8 @@ contract LM_PC_KPIRewarder_v1_deleteStuckAssertionTest is
             users, amounts, assertedIntermediateValue, true
         );
 
-        /*vm.startPrank(address(ooV3));
-        vm.expectEmit(true, true, true, true, address(kpiManager));
-        // vm.expectEmit(false, false, false, false);
-        emit DataAssertionResolved(
-            false,
-            MOCK_ASSERTION_DATA_ID,
-            bytes32(assertedIntermediateValue),
-            MOCK_ASSERTER_ADDRESS,
-            createdID
-        );
-        kpiManager.assertionResolvedCallback(createdID, false);
-        vm.stopPrank();*/
+        // Assertion could now be resolved
+        vm.warp(block.timestamp + DEFAULT_LIVENESS + 1);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -1401,5 +1426,37 @@ contract LM_PC_KPIRewarder_v1_deleteStuckAssertionTest is
             )
         );
         kpiManager.deleteStuckAssertion(createdID);
+    }
+
+    function test_deleteStuckAssertion_WhenTheAssertionCannotBeResolved(
+        address[] memory users,
+        uint[] memory amounts
+    ) external {
+        // it should revert
+
+        vm.assume(users.length > 1);
+
+        uint assertedIntermediateValue = 250;
+
+        bytes32 createdID;
+        uint totalStakedFunds;
+        (createdID, users, amounts, totalStakedFunds) =
+        setUpStateForAssertionResolution(
+            users, amounts, assertedIntermediateValue, true
+        );
+
+        // Assertion could now be resolved
+        vm.warp(block.timestamp + DEFAULT_LIVENESS + 1);
+
+        // BUT: we burn the asserter's bond in the oov3, so the transfer will revert.
+        feeToken.burn(address(ooV3), ooV3.getMinimumBond(address(feeToken)));
+
+        vm.expectEmit(true, true, true, true, address(kpiManager));
+        emit DeletedStuckAssertion(createdID);
+        kpiManager.deleteStuckAssertion(createdID);
+
+        // Check assertion data is deleted
+        assertEq(kpiManager.getAssertion(createdID).asserter, address(0)); // address(0) asserters are not possible in the system
+        assertEq(kpiManager.getAssertionConfig(createdID).creationTime, 0);
     }
 }

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -298,6 +298,67 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
 
         // (returns cappedUsers, cappedAmounts, totalUserFunds)
     }
+
+    function setUpStateForAssertionResolution(
+        address[] memory users,
+        uint[] memory amounts,
+        uint valueToAssert,
+        bool continuous
+    )
+        public
+        returns (
+            bytes32 assertionId,
+            address[] memory cappedUsers,
+            uint[] memory cappedAmounts,
+            uint totalUserFunds
+        )
+    {
+        // it should stake all orders in the stakingQueue
+        (users, amounts, totalUserFunds) = setUpStakers(users, amounts);
+
+        // prepare conditions
+        if (continuous) createDummyContinuousKPI();
+        else createDummyIncontinuousKPI();
+
+        // prepare  bond and asserter authorization
+        kpiManager.grantModuleRole(
+            kpiManager.ASSERTER_ROLE(), MOCK_ASSERTER_ADDRESS
+        );
+
+        feeToken.mint(
+            address(MOCK_ASSERTER_ADDRESS),
+            ooV3.getMinimumBond(address(feeToken))
+        ); //
+        vm.startPrank(address(MOCK_ASSERTER_ADDRESS));
+        feeToken.approve(
+            address(kpiManager), ooV3.getMinimumBond(address(feeToken))
+        );
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + 3);
+
+        // SuT
+        vm.startPrank(address(MOCK_ASSERTER_ADDRESS));
+        for (uint i = 0; i < users.length; i++) {
+            vm.expectEmit(true, true, true, true, address(kpiManager));
+            emit Staked(users[i], amounts[i]);
+        }
+
+        vm.expectEmit(true, false, false, false, address(kpiManager));
+        emit DataAsserted(
+            MOCK_ASSERTION_DATA_ID,
+            bytes32(valueToAssert),
+            MOCK_ASSERTER_ADDRESS,
+            0x0
+        ); // we don't know the last one
+
+        assertionId = kpiManager.postAssertion(
+            MOCK_ASSERTION_DATA_ID, valueToAssert, MOCK_ASSERTER_ADDRESS, 0
+        );
+        vm.stopPrank();
+
+        return (assertionId, users, amounts, totalUserFunds);
+    }
 }
 
 /*
@@ -901,67 +962,6 @@ assertionresolvedCallbackTest
 contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
     LM_PC_KPIRewarder_v1Test
 {
-    function setUpStateForAssertionResolution(
-        address[] memory users,
-        uint[] memory amounts,
-        uint valueToAssert,
-        bool continuous
-    )
-        public
-        returns (
-            bytes32 assertionId,
-            address[] memory cappedUsers,
-            uint[] memory cappedAmounts,
-            uint totalUserFunds
-        )
-    {
-        // it should stake all orders in the stakingQueue
-        (users, amounts, totalUserFunds) = setUpStakers(users, amounts);
-
-        // prepare conditions
-        if (continuous) createDummyContinuousKPI();
-        else createDummyIncontinuousKPI();
-
-        // prepare  bond and asserter authorization
-        kpiManager.grantModuleRole(
-            kpiManager.ASSERTER_ROLE(), MOCK_ASSERTER_ADDRESS
-        );
-
-        feeToken.mint(
-            address(MOCK_ASSERTER_ADDRESS),
-            ooV3.getMinimumBond(address(feeToken))
-        ); //
-        vm.startPrank(address(MOCK_ASSERTER_ADDRESS));
-        feeToken.approve(
-            address(kpiManager), ooV3.getMinimumBond(address(feeToken))
-        );
-        vm.stopPrank();
-
-        vm.warp(block.timestamp + 3);
-
-        // SuT
-        vm.startPrank(address(MOCK_ASSERTER_ADDRESS));
-        for (uint i = 0; i < users.length; i++) {
-            vm.expectEmit(true, true, true, true, address(kpiManager));
-            emit Staked(users[i], amounts[i]);
-        }
-
-        vm.expectEmit(true, false, false, false, address(kpiManager));
-        emit DataAsserted(
-            MOCK_ASSERTION_DATA_ID,
-            bytes32(valueToAssert),
-            MOCK_ASSERTER_ADDRESS,
-            0x0
-        ); // we don't know the last one
-
-        assertionId = kpiManager.postAssertion(
-            MOCK_ASSERTION_DATA_ID, valueToAssert, MOCK_ASSERTER_ADDRESS, 0
-        );
-        vm.stopPrank();
-
-        return (assertionId, users, amounts, totalUserFunds);
-    }
-
     function test_WhenTheAssertionResolvedToFalse(
         address[] memory users,
         uint[] memory amounts
@@ -1328,5 +1328,78 @@ contract LM_PC_KPIRewarder_v1_dequeueTest is LM_PC_KPIRewarder_v1Test {
                 stakingQueueLengthBefore - 1
             );
         }
+    }
+}
+/*
+    testDeleteStuckAssertion
+    ├── When the assertion isn't stored locally
+    │    └── It should revert
+    ├── When the assertion CAN be resolved
+    │    └── It should revert
+    └── When the assertion CAN NOT be resolved
+        ├── It should delete the assertion config
+        ├── It should delete the assertion data
+        ├── IT should set assertionPending to false
+        └── It should emit an event
+    */
+
+contract LM_PC_KPIRewarder_v1_deleteStuckAssertionTest is
+    LM_PC_KPIRewarder_v1Test
+{
+    function test_RevertWhen_TheAssertionIsntStoredLocally(bytes32 assertionId)
+        external
+    {
+        // it should revert
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_KPIRewarder_v1
+                    .Module__LM_PC_KPIRewarder_v1__NonExistentAssertionId
+                    .selector,
+                assertionId
+            )
+        );
+        kpiManager.deleteStuckAssertion(assertionId);
+    }
+
+    function test_RevertWhen_TheAssertionCanBeResolved(
+        address[] memory users,
+        uint[] memory amounts
+    ) external {
+        // it should revert
+
+        vm.assume(users.length > 1);
+
+        uint assertedIntermediateValue = 250;
+
+        bytes32 createdID;
+        uint totalStakedFunds;
+        (createdID, users, amounts, totalStakedFunds) =
+        setUpStateForAssertionResolution(
+            users, amounts, assertedIntermediateValue, true
+        );
+
+        /*vm.startPrank(address(ooV3));
+        vm.expectEmit(true, true, true, true, address(kpiManager));
+        // vm.expectEmit(false, false, false, false);
+        emit DataAssertionResolved(
+            false,
+            MOCK_ASSERTION_DATA_ID,
+            bytes32(assertedIntermediateValue),
+            MOCK_ASSERTER_ADDRESS,
+            createdID
+        );
+        kpiManager.assertionResolvedCallback(createdID, false);
+        vm.stopPrank();*/
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ILM_PC_KPIRewarder_v1
+                    .Module__LM_PC_KPIRewarder_v1__AssertionNotStuck
+                    .selector,
+                createdID
+            )
+        );
+        kpiManager.deleteStuckAssertion(createdID);
     }
 }

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -1237,9 +1237,12 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
 
         vm.prank(address(ooV3));
         vm.expectRevert(
-            ILM_PC_KPIRewarder_v1
-                .Module__LM_PC_KPIRewarder_v1__CallbackFromNonexistentAssertionId
-                .selector
+            abi.encodeWithSelector(
+                ILM_PC_KPIRewarder_v1
+                    .Module__LM_PC_KPIRewarder_v1__NonExistentAssertionId
+                    .selector,
+                fake_ID
+            )
         );
         kpiManager.assertionResolvedCallback(fake_ID, true);
 


### PR DESCRIPTION
**NOTE:** New version with correct commit history


## What has been done
- Added a onlyAdmin `deleteStuckAssertion()` function that allows removal of reverting assertion settlements. This function deletes local storage of the faulty assertion as if it had been asserted False and resests `asertionPending`
- Created tests for the new function