### PR TITLE
[SC-668] (Bug120) Rounding issue in rewards calculation in rewards calculation in LM_PC_KPIRewarder_v1.sol::assertionResolvedCallback

### DIFF
--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -389,7 +389,7 @@ contract LM_PC_KPIRewarder_v1 is
                             resolvedKPI.trancheValues[i] - trancheStart;
 
                         rewardAmount +=
-                            achievedReward * (trancheRewardValue / trancheEnd); // since the trancheRewardValue will be a very big number.
+                            achievedReward * trancheRewardValue / trancheEnd;
                     }
                     // else -> no reward
 

--- a/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_KPIRewarder_v1.t.sol
@@ -227,13 +227,13 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
         uint[] memory trancheValues = new uint[](3);
         uint[] memory trancheRewards = new uint[](3);
 
-        trancheValues[0] = 100;
-        trancheValues[1] = 200;
-        trancheValues[2] = 300;
+        trancheValues[0] = 100e18;
+        trancheValues[1] = 200e18;
+        trancheValues[2] = 300e18;
 
-        trancheRewards[0] = 100e18;
-        trancheRewards[1] = 100e18;
-        trancheRewards[2] = 100e18;
+        trancheRewards[0] = 100e32;
+        trancheRewards[1] = 100e32;
+        trancheRewards[2] = 100e32;
 
         kpiManager.createKPI(false, trancheValues, trancheRewards);
     }
@@ -243,13 +243,13 @@ contract LM_PC_KPIRewarder_v1Test is ModuleTest {
         uint[] memory trancheValues = new uint[](3);
         uint[] memory trancheRewards = new uint[](3);
 
-        trancheValues[0] = 100;
-        trancheValues[1] = 200;
-        trancheValues[2] = 300;
+        trancheValues[0] = 100e18;
+        trancheValues[1] = 200e18;
+        trancheValues[2] = 300e18;
 
-        trancheRewards[0] = 100e18;
-        trancheRewards[1] = 100e18;
-        trancheRewards[2] = 100e18;
+        trancheRewards[0] = 100e32;
+        trancheRewards[1] = 100e32;
+        trancheRewards[2] = 100e32;
 
         kpiManager.createKPI(true, trancheValues, trancheRewards);
     }
@@ -1012,7 +1012,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
 
         vm.assume(users.length > 1);
 
-        uint assertedIntermediateValue = 250;
+        uint assertedIntermediateValue = 250e18;
 
         bytes32 createdID;
         uint totalStakedFunds;
@@ -1033,7 +1033,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         );
 
         vm.expectEmit(true, true, true, true, address(kpiManager));
-        emit RewardSet(250e18, 1, 250e18, block.timestamp + 1);
+        emit RewardSet(250e32, 1, 250e32, block.timestamp + 1);
 
         kpiManager.assertionResolvedCallback(createdID, true);
         vm.stopPrank();
@@ -1094,7 +1094,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
     ) external whenTheAssertionResolvedToTrue {
         // it should not pay out any amount from the uncompleted tranche at all
 
-        uint assertedIntermediateValue = 250;
+        uint assertedIntermediateValue = 250e18;
 
         bytes32 createdID;
         uint totalStakedFunds;
@@ -1117,7 +1117,7 @@ contract LM_PC_KPIRewarder_v1_assertionresolvedCallbackTest is
         );
 
         vm.expectEmit(true, true, true, true, address(kpiManager));
-        emit RewardSet(200e18, 1, 200e18, block.timestamp + 1);
+        emit RewardSet(200e32, 1, 200e32, block.timestamp + 1);
 
         kpiManager.assertionResolvedCallback(createdID, true);
         vm.stopPrank();


### PR DESCRIPTION
## What has been done
- Removed the brackets in the calculation
- Significantly increased the values used in the dummy KPIs for my own peace of mind