### PR TITLE
[SC-628] Bug(47) Caps on the Rebasing FM and ElasticReceiptToken

### DIFF
--- a/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
+++ b/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
@@ -77,7 +77,9 @@ contract FM_Rebasing_v1 is
     //--------------------------------------------------------------------------
     // Constants
 
-    uint internal constant DEPOSIT_CAP = 100_000_000e18;
+    // This cap is one power of ten lower than the MAX_SUPPLY of
+    // the underlying ElasticReceiptToken, just to be safe.
+    uint internal constant DEPOSIT_CAP = 100_000_000_000_000_000e18;
 
     //--------------------------------------------------------------------------
     // Storage

--- a/src/modules/fundingManager/rebasing/abstracts/ElasticReceiptTokenBase_v1.sol
+++ b/src/modules/fundingManager/rebasing/abstracts/ElasticReceiptTokenBase_v1.sol
@@ -137,9 +137,11 @@ abstract contract ElasticReceiptTokenBase_v1 is IRebasingERC20, ERC165 {
     uint private constant MAX_UINT = type(uint).max;
 
     /// @dev The max supply target allowed.
-    /// @dev Note that this constant is internal in order for downstream
-    ////     contracts to enforce this constraint directly.
-    uint internal constant MAX_SUPPLY = 1_000_000_000e18;
+    ///      Note that this constant is internal in order for downstream
+    ///      contracts to enforce this constraint directly.
+    ///      This limit was chosen as a balance between rebasing accuracy
+    ///      and supporting low-value tokens or high decimal tokens properly.
+    uint internal constant MAX_SUPPLY = 1_000_000_000_000_000_000e18;
 
     /// @dev The total amount of bits is a multiple of MAX_SUPPLY so that
     ///      BITS_PER_UNDERLYING is an integer.

--- a/test/modules/fundingManager/rebasing/FM_Rebasing_v1.t.sol
+++ b/test/modules/fundingManager/rebasing/FM_Rebasing_v1.t.sol
@@ -397,6 +397,12 @@ contract FM_RebasingV1Test is ModuleTest {
         // Some time passes, and now half the users deposit their underliers again to continue funding (if they had any funds left).
         for (uint i; i < input.users.length / 2; ++i) {
             if (remainingFunds[i] != 0) {
+                uint actualBalance = _token.balanceOf(input.users[i]);
+                if (actualBalance < remainingFunds[i]) {
+                    // If it's not equal, it can be off by one due to rounding
+                    assertApproxEqAbs(actualBalance, remainingFunds[i], 1);
+                    remainingFunds[i] = actualBalance;
+                }
                 vm.prank(input.users[i]);
                 vm.expectEmit();
                 emit Deposit(input.users[i], input.users[i], remainingFunds[i]);

--- a/test/modules/fundingManager/rebasing/FM_Rebasing_v1.t.sol
+++ b/test/modules/fundingManager/rebasing/FM_Rebasing_v1.t.sol
@@ -44,9 +44,9 @@ contract FM_RebasingV1Test is ModuleTest {
 
     UserDeposits userDeposits;
 
-    /// The deposit cap of underlying tokens. We keep it one factor below the MAX_SUPPLY of the rebasing token.
-    /// Note that this sets the deposit limit for the fundign manager.
-    uint internal constant DEPOSIT_CAP = 100_000_000e18;
+    // This cap is one power of ten lower than the MAX_SUPPLY of
+    // the underlying ElasticReceiptToken, just to be safe.
+    uint internal constant DEPOSIT_CAP = 100_000_000_000_000_000e18;
 
     // Other constants.
     uint private constant ORCHESTRATOR_ID = 1;

--- a/test/modules/fundingManager/rebasing/abstracts/ElasticReceiptToken_v1.t.sol
+++ b/test/modules/fundingManager/rebasing/abstracts/ElasticReceiptToken_v1.t.sol
@@ -37,7 +37,7 @@ abstract contract ElasticReceiptTokenV1Test is Test {
 
     // Constants copied from SuT.
     uint internal constant MAX_UINT = type(uint).max;
-    uint internal constant MAX_SUPPLY = 1_000_000_000e18;
+    uint internal constant MAX_SUPPLY = 1_000_000_000_000_000_000e18;
     uint internal constant TOTAL_BITS = MAX_UINT - (MAX_UINT % MAX_SUPPLY);
     uint internal constant BITS_PER_UNDERLYING = TOTAL_BITS / MAX_SUPPLY;
 


### PR DESCRIPTION
WIth the limited time that I had, I validated that the math is still fine if we go from 1 billion (1e9) for the max supply to double that (1e18), to allow of low value tokens and high decimal tokens to also be used properly.

I kept them constant, as messing with them can lead to invalid states that we can't control, so this way is the safest - and it's only a receipt token anyways.

Also left the deposit cap to be one power of ten lower, as otherwise it didn't work out anymore with the tests and maths.