### PR TITLE
[SC-611] Bug(18) Reorg Issues in Factories Lead to Loss of Funds

### DIFF
--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -87,6 +87,10 @@ contract OrchestratorFactory_v1 is
     /// @dev Starts counting from 1.
     uint private _orchestratorIdCounter;
 
+    /// @dev Maps a users address to a nonce
+    ///      Used for the create2-based deployment
+    mapping(address => uint) private _deploymentNonces;
+
     // Storage gap for future upgrades
     uint[50] private __gap;
 
@@ -151,12 +155,14 @@ contract OrchestratorFactory_v1 is
             // Overwriting the independentUpdateAdmin as the ProxyAdmin will
             // be the actual admin of the proxy
             workflowConfig.independentUpdateAdmin = address(
-                new InverterProxyAdmin_v1(workflowConfig.independentUpdateAdmin)
+                new InverterProxyAdmin_v1{salt: createSalt()}(
+                    workflowConfig.independentUpdateAdmin
+                )
             );
 
             // Use an InverterTransparentUpgradeableProxy as a proxy
             proxy = address(
-                new InverterTransparentUpgradeableProxy_v1(
+                new InverterTransparentUpgradeableProxy_v1{salt: createSalt()}(
                     beacon, workflowConfig.independentUpdateAdmin, bytes("")
                 )
             );
@@ -164,7 +170,8 @@ contract OrchestratorFactory_v1 is
         // If not then
         else {
             // Instead use the Beacon Structure Proxy
-            proxy = address(new InverterBeaconProxy_v1(beacon));
+            proxy =
+                address(new InverterBeaconProxy_v1{salt: createSalt()}(beacon));
         }
 
         // Map orchestrator proxy
@@ -266,6 +273,15 @@ contract OrchestratorFactory_v1 is
                 moduleConfigs[i].configData
             );
         }
+    }
+
+    // Generated a salt for the create2-based deployment flow.
+    // This salt is the hash of (msgSender, nonce), where the
+    // nonce is an increasing number for each user.
+    function createSalt() internal returns (bytes32) {
+        return keccak256(
+            abi.encodePacked(_msgSender(), _deploymentNonces[_msgSender()]++)
+        );
     }
 
     //--------------------------------------------------------------------------

--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -346,6 +346,122 @@ contract ModuleFactoryV1Test is Test {
         ModuleImplementationV1Mock(address(newModule)).initialize(1);
     }
 
+    function testCreateModuleReorgResilience(
+        IOrchestratorFactory_v1.WorkflowConfig memory workflowConfig,
+        IModule_v1.Metadata memory metadata,
+        address orchestrator
+    ) public {
+        address alice = address(0xA11CE);
+        address bob = address(0x606);
+
+        _assumeValidMetadata(metadata);
+        _assumeValidOrchestrator(orchestrator);
+        _assumeValidWorkflowConfig(workflowConfig);
+
+        beacon.overrideImplementation(address(module));
+
+        // Register ModuleV1Mock for given metadata.
+        vm.prank(governanceContract);
+        factory.registerMetadata(metadata, beacon);
+
+        // Create a snapshot to revert to, to simulate a reorg later
+        uint snapshot = vm.snapshot();
+
+        // Since we don't know the exact address the cloned module will have, we only check that an event of the right type is fired
+        vm.expectEmit(true, false, false, false);
+
+        // We emit the event we expect to see.
+        emit ModuleCreated(
+            orchestrator, address(0), LibMetadata.identifier(metadata)
+        );
+
+        IModule_v1 originalModule;
+        vm.startPrank(alice);
+        {
+            // Create new module instance.
+            originalModule = IModule_v1(
+                factory.createModuleProxy(
+                    metadata, IOrchestrator_v1(orchestrator), workflowConfig
+                )
+            );
+        }
+        vm.stopPrank();
+
+        assertEq(
+            factory.getOrchestratorOfProxy(address(originalModule)),
+            orchestrator
+        );
+
+        // Store the code size of the module before we reorg
+        uint sizePreReorg;
+        assembly {
+            sizePreReorg := extcodesize(originalModule)
+        }
+
+        // Simulate reorg, revert to snapshot before the creation of the
+        // module.
+        vm.revertTo(snapshot);
+
+        // Store the code size of the module after we reorg
+        uint sizePostReorg;
+        assembly {
+            sizePostReorg := extcodesize(originalModule)
+        }
+
+        // Check whether the contracts actually disappeared, just to be safe
+        assertNotEq(sizePreReorg, sizePostReorg);
+        assertEq(sizePostReorg, 0);
+
+        // Since we don't know the exact address the cloned module will have, we only check that an event of the right type is fired
+        vm.expectEmit(true, false, false, false);
+
+        // We emit the event we expect to see.
+        emit ModuleCreated(
+            orchestrator, address(0), LibMetadata.identifier(metadata)
+        );
+
+        IModule_v1 redeployedModule_bob;
+        vm.startPrank(bob);
+        {
+            // Create new module instance.
+            redeployedModule_bob = IModule_v1(
+                factory.createModuleProxy(
+                    metadata, IOrchestrator_v1(orchestrator), workflowConfig
+                )
+            );
+        }
+        vm.stopPrank();
+
+        // Address shouldn't match the original one, as create2 is based on
+        // the msgSender, which isn't Alice here
+        assertNotEq(address(originalModule), address(redeployedModule_bob));
+
+        // Since we don't know the exact address the cloned module will have, we only check that an event of the right type is fired
+        vm.expectEmit(true, false, false, false);
+
+        // We emit the event we expect to see.
+        emit ModuleCreated(
+            orchestrator, address(0), LibMetadata.identifier(metadata)
+        );
+
+        IModule_v1 redeployedModule_alice;
+        vm.startPrank(alice);
+        {
+            // Create new module instance.
+            redeployedModule_alice = IModule_v1(
+                factory.createModuleProxy(
+                    metadata, IOrchestrator_v1(orchestrator), workflowConfig
+                )
+            );
+        }
+        vm.stopPrank();
+
+        // The address of the original deployment matches the one of this
+        // new deployment, even with someone else doing the same deployment.
+        // -> success!
+        assertEq(address(originalModule), address(redeployedModule_alice));
+    }
+
     function testCreateModuleFailsIfMetadataUnregistered(
         IModule_v1.Metadata memory metadata,
         address orchestrator,

--- a/test/factories/OrchestratorFactory_v1.t.sol
+++ b/test/factories/OrchestratorFactory_v1.t.sol
@@ -225,6 +225,116 @@ contract OrchestratorFactoryV1Test is Test {
         }
     }
 
+    function testCreateOrchestratorReorgResilience(
+        IOrchestratorFactory_v1.WorkflowConfig memory workflowConfig,
+        uint modulesLen
+    ) public {
+        address alice = address(0xA11CE);
+        address bob = address(0x606);
+
+        _assumeValidWorkflowConfig(workflowConfig);
+        // Note to stay reasonable
+        modulesLen = bound(modulesLen, 0, 50);
+
+        // Create optional ModuleConfig instances.
+        IOrchestratorFactory_v1.ModuleConfig[] memory moduleConfigs =
+            new IOrchestratorFactory_v1.ModuleConfig[](modulesLen);
+        for (uint i; i < modulesLen; ++i) {
+            moduleConfigs[i] = moduleConfig;
+        }
+
+        // Create a snapshot to revert to, to simulate a reorg later
+        uint snapshot = vm.snapshot();
+
+        vm.expectEmit(true, false, false, false);
+        emit OrchestratorCreated(1, address(0));
+
+        // Alice deploys original orchestrator
+        IOrchestrator_v1 orchestrator;
+        vm.startPrank(alice);
+        {
+            orchestrator = factory.createOrchestrator(
+                workflowConfig,
+                fundingManagerConfig,
+                authorizerConfig,
+                paymentProcessorConfig,
+                moduleConfigs
+            );
+        }
+        vm.stopPrank();
+
+        // Check that orchestrator's strorage correctly initialized.
+        assertEq(orchestrator.orchestratorId(), 1);
+        assertTrue(address(orchestrator.authorizer()) != address(0));
+        assertTrue(address(orchestrator.paymentProcessor()) != address(0));
+        assertTrue(address(orchestrator.governor()) == moduleFactory.governor());
+
+        // Module size should be the 3 enforced contracts + whatever is in the module config
+        assertEq(orchestrator.modulesSize(), 3 + moduleConfigs.length);
+
+        // Store the code size of the orchestrator before we reorg
+        uint sizePreReorg;
+        assembly {
+            sizePreReorg := extcodesize(orchestrator)
+        }
+
+        // Simulate reorg, revert to snapshot before the creation of the
+        // Orchestrator with id 1.
+        vm.revertTo(snapshot);
+
+        // Store the code size of the orchestrator after we reorg
+        uint sizePostReorg;
+        assembly {
+            sizePostReorg := extcodesize(orchestrator)
+        }
+
+        // Check whether the contracts actually disappeared, just to be safe
+        assertNotEq(sizePreReorg, sizePostReorg);
+        assertEq(sizePostReorg, 0);
+
+        // Simulate someone else deploying the workflow with the same exact input
+        // after the reorg
+        vm.expectEmit(true, false, false, false);
+        emit OrchestratorCreated(1, address(0));
+        IOrchestrator_v1 orchestrator_retry_bob;
+        vm.startPrank(bob);
+        {
+            orchestrator_retry_bob = factory.createOrchestrator(
+                workflowConfig,
+                fundingManagerConfig,
+                authorizerConfig,
+                paymentProcessorConfig,
+                moduleConfigs
+            );
+        }
+        vm.stopPrank();
+
+        // Address shouldn't match the original one, as create2 is based on
+        // the msgSender, which isn't Alice here
+        assertNotEq(address(orchestrator), address(orchestrator_retry_bob));
+
+        // Now Alice deploys the workflow again, after the reorg
+        vm.expectEmit(true, false, false, false);
+        emit OrchestratorCreated(2, address(0));
+        IOrchestrator_v1 orchestrator_retry_alice;
+        vm.startPrank(alice);
+        {
+            orchestrator_retry_alice = factory.createOrchestrator(
+                workflowConfig,
+                fundingManagerConfig,
+                authorizerConfig,
+                paymentProcessorConfig,
+                moduleConfigs
+            );
+        }
+        vm.stopPrank();
+
+        // The address of the original deployment matches the one of this
+        // new deployment, even with someone else doing the same deployment.
+        // -> success!
+        assertEq(address(orchestrator), address(orchestrator_retry_alice));
+    }
+
     function _deployOrchestrator() private returns (address) {
         // Create Empty ModuleConfig
         IOrchestratorFactory_v1.ModuleConfig[] memory moduleConfigs =


### PR DESCRIPTION
Switched to a create2-based workflow deployment, to prevent the following attack:
* Alice deploys a workflow
* Reorg happens, so the chain rolls back to before this happened
* Bob deploys a workflow with the same modules but him as the owner
 * The address of the workflow/orchestrator/modules would be the same
* If Alice already shared the address for deposits, users could lose funds
* If Alice redeploys now with the same config, the address of the workflow/orchestrator/modules is different

Now with this change, we base the generation of the workflow/orchestrator/modules address on the message sender and an internal nonce. This way, Bobs deployment does have a different address and Alice can (at any time) still come and redeploy with the same inputs to get the address she had before the reorg. 