### PR TITLE
[DONT MERGE YET] Sanity check paymentToken when adding paymentOrder 

### DIFF
--- a/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
+++ b/src/modules/logicModule/abstracts/ERC20PaymentClientBase_v1.sol
@@ -231,7 +231,7 @@ abstract contract ERC20PaymentClientBase_v1 is
         }
     }
 
-    function _ensureValidPaymentOrder(PaymentOrder memory order) private view {
+    function _ensureValidPaymentOrder(PaymentOrder memory order) private {
         if (!(orchestrator().paymentProcessor().validPaymentOrder(order))) {
             revert Module__ERC20PaymentClientBase__InvalidPaymentOrder();
         }

--- a/src/modules/paymentProcessor/IPaymentProcessor_v1.sol
+++ b/src/modules/paymentProcessor/IPaymentProcessor_v1.sol
@@ -109,5 +109,5 @@ interface IPaymentProcessor_v1 {
     /// @return valid Bool if the Payment Order is valid
     function validPaymentOrder(
         IERC20PaymentClientBase_v1.PaymentOrder memory order
-    ) external view returns (bool);
+    ) external returns (bool);
 }

--- a/src/modules/paymentProcessor/PP_Simple_v1.sol
+++ b/src/modules/paymentProcessor/PP_Simple_v1.sol
@@ -190,7 +190,7 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
     /// @inheritdoc IPaymentProcessor_v1
     function validPaymentOrder(
         IERC20PaymentClientBase_v1.PaymentOrder memory order
-    ) external view returns (bool) {
+    ) external returns (bool) {
         return validPaymentReceiver(order.recipient) && validTotal(order.amount)
             && validPaymentToken(order.paymentToken);
     }
@@ -245,10 +245,14 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
     /// @notice validate payment token input.
     /// @param _token Address of the token to validate.
     /// @return True if address is valid.
-    function validPaymentToken(address _token) internal view returns (bool) {
-        // Only a basic sanity check, the corresponding module should ensure it's sending an ERC20.
-        return !(
-             _token == address(this) || _token == address(orchestrator()) || _token.code.length == 0
+    function validPaymentToken(address _token) internal returns (bool) {
+        // Only a basic sanity check that the address supports the balanceOf() function. The corresponding module should ensure it's sending an ERC20.
+
+        (bool success, bytes memory data) = _token.call(
+            abi.encodeWithSelector(
+                IERC20(_token).balanceOf.selector, address(this)
+            )
         );
+        return (success && data.length != 0 && _token.code.length != 0);
     }
 }

--- a/src/modules/paymentProcessor/PP_Simple_v1.sol
+++ b/src/modules/paymentProcessor/PP_Simple_v1.sol
@@ -133,7 +133,10 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
             );
 
             //If call was success
-            if (success && (data.length == 0 || abi.decode(data, (bool)))) {
+            if (
+                success && (data.length == 0 || abi.decode(data, (bool)))
+                    && token_.code.length != 0
+            ) {
                 emit TokensReleased(recipient, token_, amount);
 
                 //Make sure to let paymentClient know that amount doesnt have to be stored anymore
@@ -245,8 +248,7 @@ contract PP_Simple_v1 is Module_v1, IPaymentProcessor_v1 {
     function validPaymentToken(address _token) internal view returns (bool) {
         // Only a basic sanity check, the corresponding module should ensure it's sending an ERC20.
         return !(
-            _token == address(0) || _token == _msgSender()
-                || _token == address(this) || _token == address(orchestrator())
+             _token == address(this) || _token == address(orchestrator()) || _token.code.length == 0
         );
     }
 }

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -387,7 +387,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     /// @inheritdoc IPaymentProcessor_v1
     function validPaymentOrder(
         IERC20PaymentClientBase_v1.PaymentOrder memory order
-    ) external view returns (bool) {
+    ) external returns (bool) {
         return validPaymentReceiver(order.recipient) && validTotal(order.amount)
             && validTimes(order.start, order.cliff, order.end)
             && validPaymentToken(order.paymentToken);
@@ -862,11 +862,14 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
     /// @notice validate payment token input.
     /// @param _token Address of the token to validate.
     /// @return True if address is valid.
-    function validPaymentToken(address _token) internal view returns (bool) {
-        // Only a basic sanity check, the corresponding module should ensure it's sending an ERC20.
-        return !(
-            _token == address(0) || _token == _msgSender()
-                || _token == address(this) || _token == address(orchestrator() || _token.code.length == 0)
+    function validPaymentToken(address _token) internal returns (bool) {
+        // Only a basic sanity check that the address supports the balanceOf() function. The corresponding module should ensure it's sending an ERC20.
+
+        (bool success, bytes memory data) = _token.call(
+            abi.encodeWithSelector(
+                IERC20(_token).balanceOf.selector, address(this)
+            )
         );
+        return (success && data.length != 0 && _token.code.length != 0);
     }
 }

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -710,7 +710,10 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
             )
         );
 
-        if (success && (data.length == 0 || abi.decode(data, (bool)))) {
+        if (
+            success && (data.length == 0 || abi.decode(data, (bool)))
+                && _token.code.length != 0
+        ) {
             emit TokensReleased(paymentReceiver, _token, amount);
 
             // Make sure to let paymentClient know that amount doesnt have to be stored anymore
@@ -863,7 +866,7 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
         // Only a basic sanity check, the corresponding module should ensure it's sending an ERC20.
         return !(
             _token == address(0) || _token == _msgSender()
-                || _token == address(this) || _token == address(orchestrator())
+                || _token == address(this) || _token == address(orchestrator() || _token.code.length == 0)
         );
     }
 }

--- a/test/modules/paymentProcessor/PP_Simple_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Simple_v1.t.sol
@@ -26,7 +26,7 @@ import {
 import {
     IERC20PaymentClientBase_v1,
     ERC20PaymentClientBaseV1Mock,
-    ERC20
+    ERC20Mock
 } from "test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1Mock.sol";
 
 // Errors
@@ -424,26 +424,30 @@ contract PP_SimpleV1Test is ModuleTest {
         assertEq(paymentProcessor.original_validTotal(_total), expectedValue);
     }
 
-    function test_validPaymentToken(address _token, address sender) public {
-        
+    function test_validPaymentToken(address randomToken, address sender)
+        public
+    {
         // Non-contract addresses or protected addresses should be invalid
-
-        bool expectedValue = false;
+        vm.assume(address(randomToken) != address(_token));
 
         vm.prank(sender);
 
         assertEq(
-            paymentProcessor.original_validPaymentToken(_token), expectedValue
+            paymentProcessor.original_validPaymentToken(randomToken), false
         );
 
-        ERC20 actualToken = ERC20(_token);
+        // ERC20 addresses are valid
+        ERC20Mock actualToken = new ERC20Mock("Test", "TST");
 
-                vm.prank(sender);
-
+        vm.prank(sender);
         assertEq(
-            paymentProcessor.original_validPaymentToken(_token), true
+            paymentProcessor.original_validPaymentToken(address(actualToken)),
+            true
         );
 
-
+        vm.prank(sender);
+        assertEq(
+            paymentProcessor.original_validPaymentToken(address(_token)), true
+        );
     }
 }

--- a/test/modules/paymentProcessor/PP_Simple_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Simple_v1.t.sol
@@ -25,7 +25,8 @@ import {
 // Mocks
 import {
     IERC20PaymentClientBase_v1,
-    ERC20PaymentClientBaseV1Mock
+    ERC20PaymentClientBaseV1Mock,
+    ERC20
 } from "test/utils/mocks/modules/paymentClient/ERC20PaymentClientBaseV1Mock.sol";
 
 // Errors
@@ -424,19 +425,25 @@ contract PP_SimpleV1Test is ModuleTest {
     }
 
     function test_validPaymentToken(address _token, address sender) public {
-        bool expectedValue = true;
-        if (
-            _token == address(0) || _token == sender
-                || _token == address(paymentProcessor)
-                || _token == address(_orchestrator)
-        ) {
-            expectedValue = false;
-        }
+        
+        // Non-contract addresses or protected addresses should be invalid
+
+        bool expectedValue = false;
 
         vm.prank(sender);
 
         assertEq(
             paymentProcessor.original_validPaymentToken(_token), expectedValue
         );
+
+        ERC20 actualToken = ERC20(_token);
+
+                vm.prank(sender);
+
+        assertEq(
+            paymentProcessor.original_validPaymentToken(_token), true
+        );
+
+
     }
 }

--- a/test/utils/mocks/modules/paymentProcessor/PP_Simple_v1AccessMock.sol
+++ b/test/utils/mocks/modules/paymentProcessor/PP_Simple_v1AccessMock.sol
@@ -22,7 +22,6 @@ contract PP_Simple_v1AccessMock is PP_Simple_v1 {
 
     function original_validPaymentToken(address _token)
         external
-        view
         returns (bool)
     {
         return validPaymentToken(_token);

--- a/test/utils/mocks/modules/paymentProcessor/PP_Streaming_v1AccessMock.sol
+++ b/test/utils/mocks/modules/paymentProcessor/PP_Streaming_v1AccessMock.sol
@@ -50,7 +50,6 @@ contract PP_Streaming_v1AccessMock is PP_Streaming_v1 {
 
     function original_validPaymentToken(address _token)
         external
-        view
         returns (bool)
     {
         return validPaymentToken(_token);


### PR DESCRIPTION
This PR started as a fix for [SC-666] (😏), but that issue turned out to be invalid. Nontheless, we still need to address the case the paymentToken isn't a correct ERC20 when adding the payment order, since if not, the call to balanceOf() in _ensureTokenBalance() would cause the processor to become stuck. This PR does that.

The branch is based on hats-fixes, but maybe it should be merged into dev?