### PR TITLE
CI: Move checks into own steps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,24 +1,27 @@
 name: Lint
 
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - '*'
+    push:
+        branches:
+            - main
+            - dev
+    pull_request:
+        branches:
+            - "*"
+
+env:
+    FOUNDRY_PROFILE: ci
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+    lint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
-        with:
-          version: nightly
+            - name: Install Foundry
+              uses: foundry-rs/foundry-toolchain@v1
+              with:
+                  version: nightly
 
-      - name: Check formatting
-        run: forge fmt --check
+            - name: Check formatting
+              run: forge fmt --check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ on:
       - '*'
 
 jobs:
-  tests:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,10 @@ on:
   push:
     branches:
       - main
+      - dev
   pull_request:
+    branches:
+      - '*'
 
 jobs:
   tests:

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,28 +1,29 @@
 name: Scripts
+
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - '*'
+    push:
+        branches:
+            - main
+            - dev
+    pull_request:
+        branches:
+            - "*"
 
 env:
-  FOUNDRY_PROFILE: ci
-  SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC }}
+    FOUNDRY_PROFILE: ci
+    SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC }}
 
 jobs:
-  verify-scripts:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+    verify-scripts:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+            - name: Install Foundry
+              uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install dependencies
-        run: make install
+            - name: Install dependencies
+              run: make install
 
-      - name: Run scripts
-        run: make testScripts
+            - name: Run scripts
+              run: make testScripts

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Scripts
 on:
   push:
     branches:
@@ -13,7 +13,7 @@ env:
   SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC }}
 
 jobs:
-  run-ci:
+  verify-scripts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -26,6 +26,3 @@ jobs:
 
       - name: Run scripts
         run: make testScripts
-
-      - name: Run tests
-        run: make test

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,27 +1,28 @@
 name: Size Check
+
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - '*'
+    push:
+        branches:
+            - main
+            - dev
+    pull_request:
+        branches:
+            - "*"
 
 env:
-  FOUNDRY_PROFILE: ci
+    FOUNDRY_PROFILE: ci
 
 jobs:
-  check-size:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+    check-size:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+            - name: Install Foundry
+              uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install dependencies
-        run: make install
+            - name: Install dependencies
+              run: make install
 
-      - name: Verify contract sizes
-        run: make check-size
+            - name: Verify contract sizes
+              run: make check-size

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Size Check
 on:
   push:
     branches:
@@ -10,7 +10,6 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
-  SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC }}
 
 jobs:
   run-ci:
@@ -24,8 +23,5 @@ jobs:
       - name: Install dependencies
         run: make install
 
-      - name: Run scripts
-        run: make testScripts
-
-      - name: Run tests
-        run: make test
+      - name: Verify contract sizes
+        run: make check-size

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,28 +1,29 @@
 name: Tests
+
 on:
-  push:
-    branches:
-      - main
-      - dev
-  pull_request:
-    branches:
-      - '*'
+    push:
+        branches:
+            - main
+            - dev
+    pull_request:
+        branches:
+            - "*"
 
 env:
-  FOUNDRY_PROFILE: ci
-  SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC }}
+    FOUNDRY_PROFILE: ci
+    SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC }}
 
 jobs:
-  verify-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
+    verify-tests:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+            - name: Install Foundry
+              uses: foundry-rs/foundry-toolchain@v1
 
-      - name: Install dependencies
-        run: make install
+            - name: Install dependencies
+              run: make install
 
-      - name: Run tests
-        run: make test
+            - name: Run tests
+              run: make test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-name: Size Check
+name: Tests
 on:
   push:
     branches:
@@ -10,9 +10,10 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
+  SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC }}
 
 jobs:
-  check-size:
+  verify-tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -23,5 +24,5 @@ jobs:
       - name: Install dependencies
         run: make install
 
-      - name: Verify contract sizes
-        run: make check-size
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
Moves the individual steps into their own task so that
* it's easier to see what exactly failed (currently it's just "CI", but could be scripts or tests or size)
* the rest still runs even if one fails (so we know whether the tests pass, even if the size is failing)