### PR TITLE
Fix: Resolve Wrong Caller Address in Factory Test

### DIFF
--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -167,6 +167,7 @@ contract ModuleFactoryV1Test is Test {
 
     function testRegisterMetadataOnlyCallableByOwner(address caller) public {
         vm.assume(caller != governanceContract);
+        vm.assume(caller != forwarder);
         vm.assume(caller != address(0));
         vm.prank(caller);
 


### PR DESCRIPTION
The fuzzing used the forwarder's address for the test, which of course fails, as this shouldn't work. 