### PR TITLE
Chore: Ensure events for state changes [SC-406]

### DIFF
--- a/src/external/fees/FeeManager_v1.sol
+++ b/src/external/fees/FeeManager_v1.sol
@@ -114,15 +114,15 @@ contract FeeManager_v1 is
         __Ownable_init(owner);
 
         // initial max fee is 10%
-        maxFee = 1000;
+        _setMaxFee(1000);
 
         if (_defaultCollateralFee > maxFee || _defaultIssuanceFee > maxFee) {
             revert FeeManager__InvalidFee();
         }
 
-        defaultProtocolTreasury = _defaultProtocolTreasury;
-        defaultCollateralFee = _defaultCollateralFee;
-        defaultIssuanceFee = _defaultIssuanceFee;
+        _setDefaultProtocolTreasury(_defaultProtocolTreasury);
+        _setDefaultCollateralFee(_defaultCollateralFee);
+        _setDefaultIssuanceFee(_defaultIssuanceFee);
     }
 
     //--------------------------------------------------------------------------
@@ -175,7 +175,8 @@ contract FeeManager_v1 is
         // In case workflow fee is set return it
         if (workflowCollateralFees[workflow][moduleFunctionHash].set) {
             return workflowCollateralFees[workflow][moduleFunctionHash].value;
-        } // otherwise return default fee
+        }
+        // otherwise return default fee
         else {
             return defaultCollateralFee;
         }
@@ -193,7 +194,8 @@ contract FeeManager_v1 is
         // In case workflow fee is set return it
         if (workflowIssuanceFees[workflow][moduleFunctionHash].set) {
             return workflowIssuanceFees[workflow][moduleFunctionHash].value;
-        } // otherwise return default fee
+        }
+        // otherwise return default fee
         else {
             return defaultIssuanceFee;
         }
@@ -231,8 +233,7 @@ contract FeeManager_v1 is
 
     /// @inheritdoc IFeeManager_v1
     function setMaxFee(uint _maxFee) external onlyOwner validMaxFee(_maxFee) {
-        maxFee = _maxFee;
-        emit MaxFeeSet(_maxFee);
+        _setMaxFee(_maxFee);
     }
 
     //---------------------------
@@ -265,20 +266,16 @@ contract FeeManager_v1 is
     function setDefaultCollateralFee(uint _defaultCollateralFee)
         external
         onlyOwner
-        validFee(_defaultCollateralFee)
     {
-        defaultCollateralFee = _defaultCollateralFee;
-        emit DefaultCollateralFeeSet(_defaultCollateralFee);
+        _setDefaultCollateralFee(_defaultCollateralFee);
     }
 
     /// @inheritdoc IFeeManager_v1
     function setDefaultIssuanceFee(uint _defaultIssuanceFee)
         external
         onlyOwner
-        validFee(_defaultIssuanceFee)
     {
-        defaultIssuanceFee = _defaultIssuanceFee;
-        emit DefaultIssuanceFeeSet(_defaultIssuanceFee);
+        _setDefaultIssuanceFee(_defaultIssuanceFee);
     }
 
     /// @inheritdoc IFeeManager_v1
@@ -288,7 +285,71 @@ contract FeeManager_v1 is
         bytes4 functionSelector,
         bool set,
         uint fee
-    ) external onlyOwner validFee(fee) {
+    ) external onlyOwner {
+        _setCollateralWorkflowFee(workflow, module, functionSelector, set, fee);
+    }
+
+    /// @inheritdoc IFeeManager_v1
+    function setIssuanceWorkflowFee(
+        address workflow,
+        address module,
+        bytes4 functionSelector,
+        bool set,
+        uint fee
+    ) external onlyOwner {
+        _setIssuanceWorkflowFee(workflow, module, functionSelector, set, fee);
+    }
+
+    //--------------------------------------------------------------------------
+    // Internal Functions
+
+    function getModuleFunctionHash(address module, bytes4 functionSelector)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(module, functionSelector));
+    }
+
+    function _setDefaultProtocolTreasury(address _defaultProtocolTreasury)
+        internal
+        validAddress(_defaultProtocolTreasury)
+    {
+        defaultProtocolTreasury = _defaultProtocolTreasury;
+        emit DefaultProtocolTreasurySet(_defaultProtocolTreasury);
+    }
+
+    function _setWorkflowTreasury(address workflow, address treasury)
+        internal
+        validAddress(treasury)
+    {
+        workflowTreasuries[workflow] = treasury;
+        emit WorkflowTreasurySet(workflow, treasury);
+    }
+
+    function _setDefaultCollateralFee(uint _defaultCollateralFee)
+        internal
+        validFee(_defaultCollateralFee)
+    {
+        defaultCollateralFee = _defaultCollateralFee;
+        emit DefaultCollateralFeeSet(_defaultCollateralFee);
+    }
+
+    function _setDefaultIssuanceFee(uint _defaultIssuanceFee)
+        internal
+        validFee(_defaultIssuanceFee)
+    {
+        defaultIssuanceFee = _defaultIssuanceFee;
+        emit DefaultIssuanceFeeSet(_defaultIssuanceFee);
+    }
+
+    function _setCollateralWorkflowFee(
+        address workflow,
+        address module,
+        bytes4 functionSelector,
+        bool set,
+        uint fee
+    ) internal validFee(fee) {
         bytes32 moduleFunctionHash =
             getModuleFunctionHash(module, functionSelector);
 
@@ -301,14 +362,13 @@ contract FeeManager_v1 is
         );
     }
 
-    /// @inheritdoc IFeeManager_v1
-    function setIssuanceWorkflowFee(
+    function _setIssuanceWorkflowFee(
         address workflow,
         address module,
         bytes4 functionSelector,
         bool set,
         uint fee
-    ) external onlyOwner validFee(fee) {
+    ) internal validFee(fee) {
         bytes32 moduleFunctionHash =
             getModuleFunctionHash(module, functionSelector);
 
@@ -321,14 +381,8 @@ contract FeeManager_v1 is
         );
     }
 
-    //--------------------------------------------------------------------------
-    // Internal Functions
-
-    function getModuleFunctionHash(address module, bytes4 functionSelector)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encodePacked(module, functionSelector));
+    function _setMaxFee(uint _maxFee) internal validMaxFee(_maxFee) {
+        maxFee = _maxFee;
+        emit MaxFeeSet(_maxFee);
     }
 }

--- a/src/external/fees/FeeManager_v1.sol
+++ b/src/external/fees/FeeManager_v1.sol
@@ -285,8 +285,17 @@ contract FeeManager_v1 is
         bytes4 functionSelector,
         bool set,
         uint fee
-    ) external onlyOwner {
-        _setCollateralWorkflowFee(workflow, module, functionSelector, set, fee);
+    ) external onlyOwner validFee(fee) {
+        bytes32 moduleFunctionHash =
+            getModuleFunctionHash(module, functionSelector);
+
+        Fee storage f = workflowCollateralFees[workflow][moduleFunctionHash];
+        f.set = set;
+        f.value = fee;
+
+        emit CollateralWorkflowFeeSet(
+            workflow, module, functionSelector, set, fee
+        );
     }
 
     /// @inheritdoc IFeeManager_v1
@@ -341,25 +350,6 @@ contract FeeManager_v1 is
     {
         defaultIssuanceFee = _defaultIssuanceFee;
         emit DefaultIssuanceFeeSet(_defaultIssuanceFee);
-    }
-
-    function _setCollateralWorkflowFee(
-        address workflow,
-        address module,
-        bytes4 functionSelector,
-        bool set,
-        uint fee
-    ) internal validFee(fee) {
-        bytes32 moduleFunctionHash =
-            getModuleFunctionHash(module, functionSelector);
-
-        Fee storage f = workflowCollateralFees[workflow][moduleFunctionHash];
-        f.set = set;
-        f.value = fee;
-
-        emit CollateralWorkflowFeeSet(
-            workflow, module, functionSelector, set, fee
-        );
     }
 
     function _setIssuanceWorkflowFee(

--- a/src/external/governance/Governor_v1.sol
+++ b/src/external/governance/Governor_v1.sol
@@ -162,7 +162,7 @@ contract Governor_v1 is
         // grant COMMUNITY_MULTISIG_ROLE to specified address
         _grantRole(TEAM_MULTISIG_ROLE, newTeamMultisig);
 
-        timelockPeriod = newTimelockPeriod;
+        _setTimelockPeriod(newTimelockPeriod);
 
         _setFeeManager(initialFeeManager);
     }
@@ -347,10 +347,8 @@ contract Governor_v1 is
     function setTimelockPeriod(uint newTimelockPeriod)
         external
         onlyRole(COMMUNITY_MULTISIG_ROLE)
-        validTimelockPeriod(newTimelockPeriod)
     {
-        timelockPeriod = newTimelockPeriod;
-        emit TimelockPeriodSet(newTimelockPeriod);
+        _setTimelockPeriod(newTimelockPeriod);
     }
 
     //---------------------------
@@ -428,6 +426,15 @@ contract Governor_v1 is
         validAddress(newFeeManager)
     {
         feeManager = IFeeManager_v1(newFeeManager);
+        emit FeeManagerUpdated(newFeeManager);
+    }
+
+    function _setTimelockPeriod(uint newTimelockPeriod)
+        internal
+        validTimelockPeriod(newTimelockPeriod)
+    {
+        timelockPeriod = newTimelockPeriod;
+        emit TimelockPeriodSet(newTimelockPeriod);
     }
 
     /// @dev internal function that checks if target address is a beacon and this contract has the ownership of it

--- a/src/external/governance/interfaces/IGovernor_v1.sol
+++ b/src/external/governance/interfaces/IGovernor_v1.sol
@@ -82,6 +82,10 @@ interface IGovernor_v1 {
     /// @param beacon The address of the beacon
     event BeaconUpgradedCanceled(address beacon);
 
+    /// @notice Event emitted when the fee manager is updated
+    /// @param feeManager The address of the fee manager
+    event FeeManagerUpdated(address feeManager);
+
     /// @notice Event emitted when a timelock period is set
     /// @param newTimelockPeriod The new timelock period
     event TimelockPeriodSet(uint newTimelockPeriod);

--- a/src/factories/ModuleFactory_v1.sol
+++ b/src/factories/ModuleFactory_v1.sol
@@ -147,6 +147,8 @@ contract ModuleFactory_v1 is
                 initialMetadataRegistration[i], initialBeaconRegistration[i]
             );
         }
+
+        emit GovernorSet(_governor);
     }
 
     //--------------------------------------------------------------------------

--- a/src/factories/OrchestratorFactory_v1.sol
+++ b/src/factories/OrchestratorFactory_v1.sol
@@ -133,9 +133,9 @@ contract OrchestratorFactory_v1 is
         ) {
             revert OrchestratorFactory__InvalidBeacon();
         }
-
         beacon = beacon_;
         moduleFactory = moduleFactory_;
+        emit OrchestratorFactoryInitialized(address(beacon_), moduleFactory_);
     }
 
     //--------------------------------------------------------------------------

--- a/src/factories/interfaces/IModuleFactory_v1.sol
+++ b/src/factories/interfaces/IModuleFactory_v1.sol
@@ -51,6 +51,10 @@ interface IModuleFactory_v1 {
         IModule_v1.Metadata metadata
     );
 
+    /// @notice Event emitted when governor is set.
+    /// @param governor The address of the governor.
+    event GovernorSet(address indexed governor);
+
     //--------------------------------------------------------------------------
     // Functions
 

--- a/src/factories/interfaces/IOrchestratorFactory_v1.sol
+++ b/src/factories/interfaces/IOrchestratorFactory_v1.sol
@@ -37,6 +37,13 @@ interface IOrchestratorFactory_v1 {
         uint indexed orchestratorId, address indexed orchestratorAddress
     );
 
+    /// @notice Event emitted when a new orchestrator factory is initialized.
+    /// @param beacon The address of the beacon associated with the factory.
+    /// @param moduleFactory The address of the module factory.
+    event OrchestratorFactoryInitialized(
+        address indexed beacon, address indexed moduleFactory
+    );
+
     //--------------------------------------------------------------------------
     // Structs
 

--- a/src/modules/base/IModule_v1.sol
+++ b/src/modules/base/IModule_v1.sol
@@ -19,9 +19,9 @@ interface IModule_v1 {
 
     /// @notice Module has been initialized.
     /// @param parentOrchestrator The address of the orchestrator the module is linked to.
-    /// @param moduleTitle The title of the module.
+    /// @param metadata The metadata of the module.
     event ModuleInitialized(
-        address indexed parentOrchestrator, string moduleTitle
+        address indexed parentOrchestrator, Metadata metadata
     );
 
     //--------------------------------------------------------------------------

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -168,7 +168,7 @@ abstract contract Module_v1 is
         }
         __Module_metadata = metadata;
 
-        emit ModuleInitialized(address(orchestrator_), metadata.title);
+        emit ModuleInitialized(address(orchestrator_), metadata);
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/fundingManager/IFundingManager_v1.sol
+++ b/src/modules/fundingManager/IFundingManager_v1.sol
@@ -39,7 +39,7 @@ interface IFundingManager_v1 {
 
     /// @notice Event emitted when collateral token has been set
     /// @param token The token that serves as collateral token making up the curve's reserve
-    event ReserveTokenSet(address indexed token, uint8 decimals);
+    event CollateralTokenSet(address indexed token, uint8 decimals);
 
     //--------------------------------------------------------------------------
     // Functions

--- a/src/modules/fundingManager/IFundingManager_v1.sol
+++ b/src/modules/fundingManager/IFundingManager_v1.sol
@@ -37,6 +37,10 @@ interface IFundingManager_v1 {
     /// @param _amount The amount of underlying tokens transfered.
     event TransferOrchestratorToken(address indexed _to, uint _amount);
 
+    /// @notice Event emitted when collateral token has been set
+    /// @param token The token that serves as collateral token making up the curve's reserve
+    event ReserveTokenSet(address indexed token, uint8 decimals);
+
     //--------------------------------------------------------------------------
     // Functions
 

--- a/src/modules/fundingManager/IFundingManager_v1.sol
+++ b/src/modules/fundingManager/IFundingManager_v1.sol
@@ -39,7 +39,7 @@ interface IFundingManager_v1 {
 
     /// @notice Event emitted when collateral token has been set
     /// @param token The token that serves as collateral token making up the curve's reserve
-    event CollateralTokenSet(address indexed token, uint8 decimals);
+    event OrchestratorTokenSet(address indexed token, uint8 decimals);
 
     //--------------------------------------------------------------------------
     // Functions

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -187,7 +187,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
         // Set selling functionality to open if true. By default selling is false
         sellIsOpen = bondingCurveProperties.sellIsOpen;
 
-        emit CollateralTokenSet(_acceptedToken, collateralTokenDecimals);
+        emit OrchestratorTokenSet(_acceptedToken, collateralTokenDecimals);
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -187,7 +187,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
         // Set selling functionality to open if true. By default selling is false
         sellIsOpen = bondingCurveProperties.sellIsOpen;
 
-        emit CollateralTokenSet(_acceptedToken, collateralTokenDecimals);
+        emit ReserveTokenSet(_acceptedToken, collateralTokenDecimals);
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.sol
@@ -187,7 +187,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupply_v1 is
         // Set selling functionality to open if true. By default selling is false
         sellIsOpen = bondingCurveProperties.sellIsOpen;
 
-        emit ReserveTokenSet(_acceptedToken, collateralTokenDecimals);
+        emit CollateralTokenSet(_acceptedToken, collateralTokenDecimals);
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/fundingManager/bondingCurve/interfaces/IBondingCurveBase_v1.sol
+++ b/src/modules/fundingManager/bondingCurve/interfaces/IBondingCurveBase_v1.sol
@@ -84,10 +84,6 @@ interface IBondingCurveBase_v1 {
         address indexed token, address indexed treasury, uint feeAmount
     );
 
-    /// @notice Event emitted when collateral token has been set
-    /// @param token The token that serves as collateral token making up the curve's reserve
-    event CollateralTokenSet(address indexed token, uint8 decimals);
-
     //--------------------------------------------------------------------------
     // Structs
     struct IssuanceToken {

--- a/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
+++ b/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
@@ -109,7 +109,9 @@ contract FM_Rebasing_v1 is IFundingManager_v1, ElasticReceiptTokenBase_v1 {
             orchestrator_, metadata, underlyingConfigData
         );
 
-        emit CollateralTokenSet(orchestratorTokenAddress, reserveTokenDecimals);
+        emit OrchestratorTokenSet(
+            orchestratorTokenAddress, reserveTokenDecimals
+        );
     }
 
     function token() public view returns (IERC20) {

--- a/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
+++ b/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
@@ -94,19 +94,22 @@ contract FM_Rebasing_v1 is IFundingManager_v1, ElasticReceiptTokenBase_v1 {
     ) external override(ElasticReceiptTokenBase_v1) initializer {
         address orchestratorTokenAddress = abi.decode(configData, (address));
         _token = IERC20(orchestratorTokenAddress);
+        uint8 reserveTokenDecimals =
+            IERC20Metadata(orchestratorTokenAddress).decimals();
 
         string memory _id = orchestrator_.orchestratorId().toString();
         string memory _name = string(
             abi.encodePacked("Inverter Funding Token - Orchestrator_v1 #", _id)
         );
         string memory _symbol = string(abi.encodePacked("IFT-", _id));
-        bytes memory underlyingConfigData = abi.encode(
-            _name, _symbol, IERC20Metadata(orchestratorTokenAddress).decimals()
-        );
+        bytes memory underlyingConfigData =
+            abi.encode(_name, _symbol, reserveTokenDecimals);
         // Initial upstream contracts.
         __ElasticReceiptTokenBase_init(
             orchestrator_, metadata, underlyingConfigData
         );
+
+        emit ReserveTokenSet(orchestratorTokenAddress, reserveTokenDecimals);
     }
 
     function token() public view returns (IERC20) {

--- a/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
+++ b/src/modules/fundingManager/rebasing/FM_Rebasing_v1.sol
@@ -109,7 +109,7 @@ contract FM_Rebasing_v1 is IFundingManager_v1, ElasticReceiptTokenBase_v1 {
             orchestrator_, metadata, underlyingConfigData
         );
 
-        emit ReserveTokenSet(orchestratorTokenAddress, reserveTokenDecimals);
+        emit CollateralTokenSet(orchestratorTokenAddress, reserveTokenDecimals);
     }
 
     function token() public view returns (IERC20) {

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -188,6 +188,7 @@ contract LM_PC_KPIRewarder_v1 is
 
         assertionPending = true;
 
+        // TODO
         // (return assertionId)
     }
 
@@ -258,8 +259,8 @@ contract LM_PC_KPIRewarder_v1 is
         return (KpiNum);
     }
 
-    // ===========================================================
-    // Overrides:
+    //--------------------------------------------------------------------------
+    // New user facing functions (stake() is a LM_PC_Staking_v1 override) :
 
     /// @inheritdoc ILM_PC_Staking_v1
     function stake(uint amount)
@@ -361,7 +362,7 @@ contract LM_PC_KPIRewarder_v1 is
                             resolvedKPI.trancheValues[i] - trancheStart;
 
                         rewardAmount +=
-                            achievedReward * trancheRewardValue / trancheEnd;
+                            (achievedReward * trancheRewardValue) / trancheEnd;
                     }
                     // else -> no reward
 

--- a/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/LM_PC_KPIRewarder_v1.sol
@@ -188,7 +188,6 @@ contract LM_PC_KPIRewarder_v1 is
 
         assertionPending = true;
 
-        // TODO
         // (return assertionId)
     }
 

--- a/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/LM_PC_RecurringPayments_v1.sol
@@ -116,12 +116,15 @@ contract LM_PC_RecurringPayments_v1 is
         // Set empty list of RecurringPayment
         _paymentList.init();
 
-        epochLength = abi.decode(configData, (uint));
+        uint newEpochLength = abi.decode(configData, (uint));
+        epochLength = newEpochLength;
 
         // revert if not at least 1 week and at most a year
         if (epochLength < 1 weeks || epochLength > 52 weeks) {
             revert Module__LM_PC_RecurringPayments__InvalidEpochLength();
         }
+
+        emit EpochLengthSet(newEpochLength);
     }
 
     //--------------------------------------------------------------------------

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -150,7 +150,7 @@ contract LM_PC_Staking_v1 is
             // Get full amount back
             return amount * duration * rewardRate;
         }
-        return amount * duration * rewardRate / totalSupply;
+        return (amount * duration * rewardRate) / totalSupply;
     }
 
     //--------------------------------------------------------------------------
@@ -239,16 +239,21 @@ contract LM_PC_Staking_v1 is
     /// @dev This has to trigger on every major change of the state of the contract
     function _update(address triggerAddress) internal {
         // Set a new reward value
-        rewardValue = _calculateRewardValue();
+        uint newRewardValue = _calculateRewardValue();
+        rewardValue = newRewardValue;
 
         // Set timestamp correctly
-        lastUpdate = _getRewardDistributionTimestamp();
+        uint newLastUpdate = _getRewardDistributionTimestamp();
+        lastUpdate = newLastUpdate;
 
         // If trigger address is 0 then its not a user
+        uint earned;
         if (triggerAddress != address(0)) {
-            rewards[triggerAddress] = _earned(triggerAddress, rewardValue);
+            earned = _earned(triggerAddress, rewardValue);
+            rewards[triggerAddress] = earned;
             userRewardValue[triggerAddress] = rewardValue;
         }
+        emit Updated(triggerAddress, newRewardValue, newLastUpdate, earned);
     }
 
     /// @dev This is the heart of the algorithm
@@ -262,9 +267,11 @@ contract LM_PC_Staking_v1 is
             return rewardValue;
         }
 
-        return (_getRewardDistributionTimestamp() - lastUpdate) // Get the time difference between the last time it was updated and now (or in case the reward period ended the rewardEnd timestamp)
-            * rewardRate // Multiply it with the rewardrate to get the rewards distributed for all of the stakers together
-            * 1e36 // for the later division we need a value to compensate for the loss of precision. This value will be counteracted in earned()
+        return (
+            (_getRewardDistributionTimestamp() - lastUpdate) * rewardRate * 1e36
+        ) // Get the time difference between the last time it was updated and now (or in case the reward period ended the rewardEnd timestamp)
+            // Multiply it with the rewardrate to get the rewards distributed for all of the stakers together
+            // for the later division we need a value to compensate for the loss of precision. This value will be counteracted in earned()
             / totalSupply // divide it by the totalSupply to get the rewards per token
             + rewardValue; // add the old rewardValue to the new "single" rewardValue
     }
@@ -284,8 +291,8 @@ contract LM_PC_Staking_v1 is
         view
         returns (uint)
     {
-        return (providedRewardValue - userRewardValue[user]) // This difference in rewardValues basically represents the time period between now and the moment the userRewardValue was created
-            * _balances[user] // multiply by users balance of tokens to get their share of the token rewards
+        return ((providedRewardValue - userRewardValue[user]) * _balances[user]) // This difference in rewardValues basically represents the time period between now and the moment the userRewardValue was created
+            // multiply by users balance of tokens to get their share of the token rewards
             / 1e36 // See comment in _calculateRewardValue();
             + rewards[user];
     }
@@ -354,5 +361,6 @@ contract LM_PC_Staking_v1 is
             revert Module__LM_PC_Staking_v1__InvalidStakingToken();
         }
         stakingToken = _token;
+        emit StakingTokenSet(_token);
     }
 }

--- a/src/modules/logicModule/LM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/LM_PC_Staking_v1.sol
@@ -267,11 +267,9 @@ contract LM_PC_Staking_v1 is
             return rewardValue;
         }
 
-        return (
-            (_getRewardDistributionTimestamp() - lastUpdate) * rewardRate * 1e36
-        ) // Get the time difference between the last time it was updated and now (or in case the reward period ended the rewardEnd timestamp)
-            // Multiply it with the rewardrate to get the rewards distributed for all of the stakers together
-            // for the later division we need a value to compensate for the loss of precision. This value will be counteracted in earned()
+        return (_getRewardDistributionTimestamp() - lastUpdate) // Get the time difference between the last time it was updated and now (or in case the reward period ended the rewardEnd timestamp)
+            * rewardRate // Multiply it with the rewardrate to get the rewards distributed for all of the stakers together
+            * 1e36 // for the later division we need a value to compensate for the loss of precision. This value will be counteracted in earned()
             / totalSupply // divide it by the totalSupply to get the rewards per token
             + rewardValue; // add the old rewardValue to the new "single" rewardValue
     }
@@ -291,8 +289,8 @@ contract LM_PC_Staking_v1 is
         view
         returns (uint)
     {
-        return ((providedRewardValue - userRewardValue[user]) * _balances[user]) // This difference in rewardValues basically represents the time period between now and the moment the userRewardValue was created
-            // multiply by users balance of tokens to get their share of the token rewards
+        return (providedRewardValue - userRewardValue[user]) // This difference in rewardValues basically represents the time period between now and the moment the userRewardValue was created
+            * _balances[user] // multiply by users balance of tokens to get their share of the token rewards
             / 1e36 // See comment in _calculateRewardValue();
             + rewards[user];
     }

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -125,8 +125,7 @@ interface ILM_PC_KPIRewarder_v1 {
 
     /// @notice Returns the Assertion Configuration for a given assertionId
     /// @param assertionId The id of the Assertion to return
-    function getAssertionConfig(bytes32 assertionId)
-        external
-        view
-        returns (RewardRoundConfiguration memory);
+    function getAssertionConfig(
+        bytes32 assertionId
+    ) external view returns (RewardRoundConfiguration memory);
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_KPIRewarder_v1.sol
@@ -125,7 +125,8 @@ interface ILM_PC_KPIRewarder_v1 {
 
     /// @notice Returns the Assertion Configuration for a given assertionId
     /// @param assertionId The id of the Assertion to return
-    function getAssertionConfig(
-        bytes32 assertionId
-    ) external view returns (RewardRoundConfiguration memory);
+    function getAssertionConfig(bytes32 assertionId)
+        external
+        view
+        returns (RewardRoundConfiguration memory);
 }

--- a/src/modules/logicModule/interfaces/ILM_PC_RecurringPayments_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_RecurringPayments_v1.sol
@@ -51,6 +51,10 @@ interface ILM_PC_RecurringPayments_v1 {
     /// @param currentEpoch The current epoch.
     event RecurringPaymentsTriggered(uint indexed currentEpoch);
 
+    /// @notice Event emitted when the epoch length is set.
+    /// @param epochLength The epoch length.
+    event EpochLengthSet(uint epochLength);
+
     //--------------------------------------------------------------------------
     // Getter Functions
 

--- a/src/modules/logicModule/interfaces/ILM_PC_Staking_v1.sol
+++ b/src/modules/logicModule/interfaces/ILM_PC_Staking_v1.sol
@@ -30,6 +30,22 @@ interface ILM_PC_Staking_v1 {
     /// @notice Event emitted when a user receives Rewards.
     event RewardsDistributed(address indexed user, uint amount);
 
+    /// @notice Event emitted for each major change of state.
+    /// @param triggerAddress Address of user if state change was triggered by a staking action. Else can be zero.
+    /// @param rewardValue Variable necessary to calculate how much rewards a staker is eligible for.
+    /// @param lastUpdate Timestamp of last state change.
+    /// @param earnedRewards How much a user earned up to point of state change.
+    event Updated(
+        address indexed triggerAddress,
+        uint rewardValue,
+        uint lastUpdate,
+        uint earnedRewards
+    );
+
+    /// @notice Event emitted when staking token is set.
+    /// @param token Address of token that can be staked.
+    event StakingTokenSet(address indexed token);
+
     //--------------------------------------------------------------------------
     // Getter Functions
 

--- a/src/modules/paymentProcessor/PP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/PP_Streaming_v1.sol
@@ -625,6 +625,8 @@ contract PP_Streaming_v1 is Module_v1, IPP_Streaming_v1 {
 
         // pop the last element of the array
         activePaymentReceivers[client].pop();
+
+        emit PaymentReceiverRemoved(client, paymentReceiver);
     }
 
     /// @notice Adds a new payment containing the details of the monetary flow

--- a/src/modules/paymentProcessor/interfaces/IPP_Streaming_v1.sol
+++ b/src/modules/paymentProcessor/interfaces/IPP_Streaming_v1.sol
@@ -115,6 +115,13 @@ interface IPP_Streaming_v1 is IPaymentProcessor_v1 {
         uint amount
     );
 
+    /// @notice Emitted when an address is removed from the list of active payment receiver, eg because all payments have been fulfilled by a client.
+    /// @param paymentClient The address of the payment client.
+    /// @param paymentReceiver The address of the recipient that is removed.
+    event PaymentReceiverRemoved(
+        address indexed paymentClient, address indexed paymentReceiver
+    );
+
     //--------------------------------------------------------------------------
     // Errors
 

--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -71,6 +71,8 @@ contract ModuleFactoryV1Test is Test {
         IModule_v1.Metadata metadata
     );
 
+    event GovernorSet(address indexed governor);
+
     // Constants
     uint constant MAJOR_VERSION = 1;
     uint constant MINOR_VERSION = 0;
@@ -89,6 +91,8 @@ contract ModuleFactoryV1Test is Test {
 
         address impl = address(new ModuleFactory_v1(reverter, address(0)));
         factory = ModuleFactory_v1(Clones.clone(impl));
+        vm.expectEmit(true, false, false, false);
+        emit GovernorSet(governanceContract);
         factory.init(
             governanceContract,
             new IModule_v1.Metadata[](0),

--- a/test/factories/OrchestratorFactory_v1.t.sol
+++ b/test/factories/OrchestratorFactory_v1.t.sol
@@ -54,6 +54,9 @@ contract OrchestratorFactoryV1Test is Test {
     event OrchestratorCreated(
         uint indexed orchestratorId, address indexed orchestratorAddress
     );
+    event OrchestratorFactoryInitialized(
+        address indexed beacon, address indexed moduleFactory
+    );
 
     // Mocks
     ModuleFactoryV1Mock moduleFactory;
@@ -103,6 +106,10 @@ contract OrchestratorFactoryV1Test is Test {
 
         address impl = address(new OrchestratorFactory_v1(address(0)));
         factory = OrchestratorFactory_v1(Clones.clone(impl));
+        vm.expectEmit(true, false, false, false);
+        emit OrchestratorFactoryInitialized(
+            address(beacon), address(moduleFactory)
+        );
         factory.init(moduleFactory.governor(), beacon, address(moduleFactory));
     }
 

--- a/test/modules/base/Module_v1.t.sol
+++ b/test/modules/base/Module_v1.t.sol
@@ -50,9 +50,9 @@ contract ModuleBaseV1Test is ModuleTest {
 
     /// @notice Module has been initialized.
     /// @param parentOrchestrator The address of the orchestrator the module is linked to.
-    /// @param moduleTitle The title of the module.
+    /// @param metadata The metadata of the module.
     event ModuleInitialized(
-        address indexed parentOrchestrator, string moduleTitle
+        address indexed parentOrchestrator, IModule_v1.Metadata metadata
     );
 
     function setUp() public {
@@ -62,7 +62,7 @@ contract ModuleBaseV1Test is ModuleTest {
         _setUpOrchestrator(module);
 
         vm.expectEmit(true, true, true, false);
-        emit ModuleInitialized(address(_orchestrator), _TITLE);
+        emit ModuleInitialized(address(_orchestrator), _METADATA);
 
         module.init(_orchestrator, _METADATA, _CONFIGDATA);
     }

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -108,7 +108,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     event VirtualIssuanceSupplySet(uint newSupply, uint oldSupply);
     event VirtualCollateralSupplySet(uint newSupply, uint oldSupply);
     event TransferOrchestratorToken(address indexed to, uint amount);
-    event ReserveTokenSet(address indexed token, uint8 decimals);
+    event CollateralTokenSet(address indexed token, uint8 decimals);
 
     function setUp() public virtual {
         // Deploy contracts
@@ -142,7 +142,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         _authorizer.grantRole(_authorizer.getAdminRole(), admin_address);
 
         vm.expectEmit(true, true, true, true);
-        emit ReserveTokenSet(address(_token), DECIMALS);
+        emit CollateralTokenSet(address(_token), DECIMALS);
 
         // Init Module
         bondingCurveFundingManager.init(

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -108,7 +108,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     event VirtualIssuanceSupplySet(uint newSupply, uint oldSupply);
     event VirtualCollateralSupplySet(uint newSupply, uint oldSupply);
     event TransferOrchestratorToken(address indexed to, uint amount);
-    event CollateralTokenSet(address indexed token, uint8 decimals);
+    event OrchestratorTokenSet(address indexed token, uint8 decimals);
 
     function setUp() public virtual {
         // Deploy contracts
@@ -142,7 +142,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         _authorizer.grantRole(_authorizer.getAdminRole(), admin_address);
 
         vm.expectEmit(true, true, true, true);
-        emit CollateralTokenSet(address(_token), DECIMALS);
+        emit OrchestratorTokenSet(address(_token), DECIMALS);
 
         // Init Module
         bondingCurveFundingManager.init(

--- a/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
+++ b/test/modules/fundingManager/bondingCurve/FM_BC_Bancor_Redeeming_VirtualSupply_v1.t.sol
@@ -108,7 +108,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
     event VirtualIssuanceSupplySet(uint newSupply, uint oldSupply);
     event VirtualCollateralSupplySet(uint newSupply, uint oldSupply);
     event TransferOrchestratorToken(address indexed to, uint amount);
-    event CollateralTokenSet(address indexed token, uint8 decimals);
+    event ReserveTokenSet(address indexed token, uint8 decimals);
 
     function setUp() public virtual {
         // Deploy contracts
@@ -142,7 +142,7 @@ contract FM_BC_Bancor_Redeeming_VirtualSupplyV1Test is ModuleTest {
         _authorizer.grantRole(_authorizer.getAdminRole(), admin_address);
 
         vm.expectEmit(true, true, true, true);
-        emit CollateralTokenSet(address(_token), DECIMALS);
+        emit ReserveTokenSet(address(_token), DECIMALS);
 
         // Init Module
         bondingCurveFundingManager.init(

--- a/test/modules/logicModule/LM_PC_Staking_v1.t.sol
+++ b/test/modules/logicModule/LM_PC_Staking_v1.t.sol
@@ -48,6 +48,13 @@ contract LM_PC_Staking_v1Test is ModuleTest {
     event Staked(address indexed user, uint amount);
     event Unstaked(address indexed user, uint amount);
     event RewardsDistributed(address indexed user, uint amount);
+    event Updated(
+        address indexed triggerAddress,
+        uint rewardValue,
+        uint lastUpdate,
+        uint earnedRewards
+    );
+    event StakingTokenSet(address indexed token);
 
     function setUp() public {
         // Add Module to Mock Orchestrator
@@ -56,7 +63,8 @@ contract LM_PC_Staking_v1Test is ModuleTest {
 
         _setUpOrchestrator(stakingManager);
         _authorizer.setIsAuthorized(address(this), true);
-
+        vm.expectEmit(true, true, true, true);
+        emit StakingTokenSet(address(stakingToken));
         stakingManager.init(
             _orchestrator, _METADATA, abi.encode(address(stakingToken))
         );
@@ -530,6 +538,10 @@ contract LM_PC_Staking_v1Test is ModuleTest {
             expectedUserRewardValue =
                 stakingManager.direct_calculateRewardValue();
         }
+        vm.expectEmit(true, true, true, false);
+        emit Updated(
+            trigger, expectedRewards, stakingManager.getLastUpdate(), 0
+        );
 
         stakingManager.direct_update(trigger);
 

--- a/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/LM_PC_RecurringPayments_v1.t.sol
@@ -40,6 +40,7 @@ contract LM_PC_RecurringV1Test is ModuleTest {
     );
     event RecurringPaymentRemoved(uint indexed recurringPaymentId);
     event RecurringPaymentsTriggered(uint indexed currentEpoch);
+    event EpochLengthSet(uint epochLength);
 
     function setUp() public {
         // Add Module to Mock Orchestrator_v1
@@ -68,6 +69,9 @@ contract LM_PC_RecurringV1Test is ModuleTest {
                 .Module__LM_PC_RecurringPayments__InvalidEpochLength
                 .selector
         );
+
+        vm.expectEmit(true, true, true, true);
+        emit EpochLengthSet(1 weeks);
 
         // Init Module wrongly
         recurringPaymentManager.init(

--- a/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
@@ -91,6 +91,10 @@ contract PP_StreamingV1Test is ModuleTest {
         address indexed recipient, address indexed token, uint amount
     );
 
+    event PaymentReceiverRemoved(
+        address indexed paymentClient, address indexed paymentReceiver
+    );
+
     function setUp() public {
         address impl = address(new PP_Streaming_v1AccessMock());
         paymentProcessor = PP_Streaming_v1AccessMock(Clones.clone(impl));
@@ -1314,6 +1318,10 @@ contract PP_StreamingV1Test is ModuleTest {
 
         // calling cancelRunningPayments also calls claim() so no need to repeat?
         vm.prank(address(paymentClient));
+        vm.expectEmit(true, true, true, true);
+        emit PaymentReceiverRemoved(
+            address(paymentClient), recipients[0]
+        );
         paymentProcessor.cancelRunningPayments(paymentClient);
 
         // measure recipients balances before attempting second claim.

--- a/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
@@ -1319,9 +1319,7 @@ contract PP_StreamingV1Test is ModuleTest {
         // calling cancelRunningPayments also calls claim() so no need to repeat?
         vm.prank(address(paymentClient));
         vm.expectEmit(true, true, true, true);
-        emit PaymentReceiverRemoved(
-            address(paymentClient), recipients[0]
-        );
+        emit PaymentReceiverRemoved(address(paymentClient), recipients[0]);
         paymentProcessor.cancelRunningPayments(paymentClient);
 
         // measure recipients balances before attempting second claim.


### PR DESCRIPTION
DONE:
* added a bunch of events and internal setters
* added back metadata as param for ModuleInitialized cause I realized it's needed to be able to compute the module id

DID NOT DO:
* ProtocolFeeCollected event for buy and sell orders (to save gas for end users)
* no events for modifications on `_bitsPerToken` and `_accountBits` on Elastic Receipt Token