### PR TITLE
Fix: Resolve Failing Factory Test

### DIFF
--- a/test/factories/ModuleFactory_v1.t.sol
+++ b/test/factories/ModuleFactory_v1.t.sol
@@ -271,6 +271,7 @@ contract ModuleFactoryV1Test is Test {
         address reverterAddress
     ) public {
         beacon.overrideReverter(reverterAddress);
+        beacon.overrideImplementation(address(new ModuleImplementationV2Mock()));
 
         if (reverterAddress != factory.reverter()) {
             vm.expectRevert(


### PR DESCRIPTION
The CI was failing sometimes - this resolves it.

**Explanation**
The test `testRegisterMetadataFailsIfBeaconIsNotLinkedToFactoryReverter` was failing, in the case where the fuzz engine selected the new `reverter` to be the same as the existing one in factory. In this case, the `registerMetadata` call shouldn't fail, which it did because the implementation was reported to be zero. I added a line there to properly set an implementation to resolve this.