### PR TITLE
Fix: Exclude Create2Deployer address from paymentToken test

### DIFF
--- a/src/proxies/InverterBeacon_v1.sol
+++ b/src/proxies/InverterBeacon_v1.sol
@@ -63,10 +63,10 @@ contract InverterBeacon_v1 is IInverterBeacon_v1, ERC165, Ownable2Step {
     ) {
         if (
             // Minor Version cant go down
-            newMinorVersion < minorVersion
             // Patch Version cant go down or stay the same if minorVersion stays the same
-            || newPatchVersion <= patchVersion
-                && newMinorVersion == minorVersion
+            newMinorVersion < minorVersion
+                || newPatchVersion <= patchVersion
+                    && newMinorVersion == minorVersion
         ) {
             revert InverterBeacon__InvalidImplementationMinorOrPatchVersion();
         }

--- a/test/modules/paymentProcessor/PP_Simple_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Simple_v1.t.sol
@@ -382,6 +382,13 @@ contract PP_SimpleV1Test is ModuleTest {
         IERC20PaymentClientBase_v1.PaymentOrder memory order,
         address sender
     ) public {
+        // The randomToken can't be the address of the Create2Deployer
+        // as that one uses a fallback funciton to deploy contracts, it will
+        // pass the test here
+        vm.assume(
+            order.paymentToken != 0x4e59b44847b379578588920cA78FbF26c0B4956C
+        );
+
         order.start = bound(order.start, 0, type(uint).max / 2);
         order.cliff = bound(order.cliff, 0, type(uint).max / 2);
 
@@ -428,7 +435,12 @@ contract PP_SimpleV1Test is ModuleTest {
         public
     {
         // Non-contract addresses or protected addresses should be invalid
-        vm.assume(address(randomToken) != address(_token));
+        vm.assume(randomToken != address(_token));
+
+        // The randomToken can't be the address of the Create2Deployer
+        // as that one uses a fallback funciton to deploy contracts, it will
+        // pass the test here
+        vm.assume(randomToken != 0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
         vm.prank(sender);
 

--- a/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
+++ b/test/modules/paymentProcessor/PP_Streaming_v1.t.sol
@@ -1829,6 +1829,13 @@ contract PP_StreamingV1Test is ModuleTest {
         IERC20PaymentClientBase_v1.PaymentOrder memory order,
         address sender
     ) public {
+        // The randomToken can't be the address of the Create2Deployer
+        // as that one uses a fallback funciton to deploy contracts, it will
+        // pass the test here
+        vm.assume(
+            order.paymentToken != 0x4e59b44847b379578588920cA78FbF26c0B4956C
+        );
+
         order.start = bound(order.start, 0, type(uint).max / 2);
         order.cliff = bound(order.cliff, 0, type(uint).max / 2);
 
@@ -1892,7 +1899,12 @@ contract PP_StreamingV1Test is ModuleTest {
         public
     {
         // Non-contract addresses or protected addresses should be invalid
-        vm.assume(address(randomToken) != address(_token));
+        vm.assume(randomToken != address(_token));
+
+        // The randomToken can't be the address of the Create2Deployer
+        // as that one uses a fallback funciton to deploy contracts, it will
+        // pass the test here
+        vm.assume(randomToken != 0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
         vm.prank(sender);
 


### PR DESCRIPTION
Fixes the failing CI on `dev`, as this test fails. Just had to exclude the specific Create2Deployer address (which the fuzz engine of course insistent on hitting). We did this in other parts of the code as well.

As that is using the fallback function to deploy contracts, the `paymentToken` check was confused as it didn't fail 🗡️ 

**Note**: Foundry had an update, the formatter works slightly differently, so one instance is now reformatterd (the versioning thing), that's normal and needs to happen.