### PR TITLE
Fix: Restore right Environment for CI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,4 +145,4 @@ jobs:
                       cache/
 
             - name: Run tests
-              run: make test
+              run: forge test -vvv


### PR DESCRIPTION
In one of the last PRs (#632) we added general public RPCs for all test chains to the `dev.env`. The issue was, that we overwrote the RPC in the repo secrets so we have a paid, working rpc in there that we can rely on. This wasn't taken anymore as the Makefile overwrites it again with the contents of `dev.env`.  Easy solution was to not make use of the Makefile for tests, which is where we use the Sepolia RPC (which is set elsewhere for the CI). Works fine!