### PR TITLE
[Audit] Apply Hats Fixes from Macro Audit

### DIFF
--- a/src/modules/authorizer/IAuthorizer_v1.sol
+++ b/src/modules/authorizer/IAuthorizer_v1.sol
@@ -27,13 +27,16 @@ interface IAuthorizer_v1 is IAccessControlEnumerable {
     //--------------------------------------------------------------------------
     // Functions
 
-    /// @notice Asks whether an address holds the required module role to execute
+    /// @notice Asks whether an address holds the required role to execute
     ///         the current transaction.
+    /// @dev The calling contract needs to generate the right role ID using its
+    ///      own address and the role identifier.
+    ///      In modules, this function should be used instead of hasRole, as
+    ///      there are Authorizer-specific checks that need to be performed.
     /// @param role The identifier of the role we want to check
     /// @param who  The address on which to perform the check.
     /// @return bool Returns if the address holds the role
-    /// @dev It will use the calling address to generate the role ID. Therefore, for checking on anything other than itself, hasRole() should be used
-    function hasModuleRole(bytes32 role, address who)
+    function checkForRole(bytes32 role, address who)
         external
         view
         returns (bool);
@@ -44,6 +47,7 @@ interface IAuthorizer_v1 is IAccessControlEnumerable {
     /// @return bytes32 Returns the generated role hash
     function generateRoleId(address module, bytes32 role)
         external
+        pure
         returns (bytes32);
 
     /// @notice Used by a Module to grant a role to a user.

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -138,15 +138,13 @@ contract AUT_Roles_v1 is
     // Public functions
 
     /// @inheritdoc IAuthorizer_v1
-    function hasModuleRole(bytes32 role, address who)
+    function checkForRole(bytes32 role, address who)
         external
         view
         virtual
         returns (bool)
     {
-        // Note: since it uses msgSenderto generate ID, this should only be used by modules. Users should call hasRole()
-        bytes32 roleId = generateRoleId(_msgSender(), role);
-        return hasRole(roleId, who);
+        return hasRole(role, who);
     }
 
     /// @inheritdoc IAuthorizer_v1

--- a/src/modules/authorizer/role/AUT_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_Roles_v1.sol
@@ -279,7 +279,7 @@ contract AUT_Roles_v1 is
     }
 
     /// @notice Overrides {_grantRole} to prevent having the Orchestrator having the OWNER role
-    /// @param role The id number of the role
+    /// @param role The id of the role
     /// @param who The user we want to check on
     /// @return bool Returns if grant has been succesful
     function _grantRole(bytes32 role, address who)

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -306,20 +306,17 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     /// @inheritdoc IAuthorizer_v1
     /// @notice In case the role is token gated, it will check if {who} holds a balance
     ///         above the threshold for at least one of the required tokens
-    /// @dev Since this function uses msgSender to generate the roleId, this should only
-    ///      be used by modules. Users should call hasRole() or hasTokenRole().
-    function hasModuleRole(bytes32 role, address who)
+    function checkForRole(bytes32 role, address who)
         external
         view
         virtual
         override(AUT_Roles_v1, IAuthorizer_v1)
         returns (bool)
     {
-        bytes32 roleId = generateRoleId(_msgSender(), role);
-        if (isTokenGated[roleId]) {
-            return _hasTokenRole(roleId, who);
+        if (isTokenGated[role]) {
+            return _hasTokenRole(role, who);
         } else {
-            return hasRole(roleId, who);
+            return hasRole(role, who);
         }
     }
 }

--- a/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/AUT_TokenGated_Roles_v1.sol
@@ -191,8 +191,8 @@ contract AUT_TokenGated_Roles_v1 is IAUT_TokenGated_Roles_v1, AUT_Roles_v1 {
     /// @notice Grants a role to an address
     /// @param role The role to grant
     /// @param who The address to grant the role to
-    /// @return bool Returns if the role has been granted succesful
-    /// @dev Overrides {_grantRole} from AccessControl to enforce interface implementation and threshold existence when role is token-gated
+    /// @return bool Returns true if the role has been granted succesfully
+    /// @dev Overrides {_grantRole} from AUT_ROLES_v1 to enforce interface implementation and threshold existence when role is token-gated
     /// @dev Please note: current check for validating a valid token is not conclusive and could be
     ///         circumvented through a callback() function
     function _grantRole(bytes32 role, address who)

--- a/src/modules/authorizer/role/interfaces/IAUT_TokenGated_Roles_v1.sol
+++ b/src/modules/authorizer/role/interfaces/IAUT_TokenGated_Roles_v1.sol
@@ -54,10 +54,13 @@ interface IAUT_TokenGated_Roles_v1 is IAuthorizer_v1 {
         view
         returns (bool);
 
-    /// @notice Returns the threshold amount necessary to qualify for a given token role
+    /// @notice Returns the threshold balance for a given token necessary to qualify for a
+    ///         specific role. If the value is 0, the supplied token is not part of the
+    ///         role's token gating.
+    /// @dev In case the queried role is not token gated, all calls will return 0.
     /// @param roleId The role to be checked on.
     /// @param token The token to check the threshold for.
-    /// @return The threshold amount necessary to qualify for a given token role
+    /// @return The threshold amount necessary to qualify for a given token role.
     function getThresholdValue(bytes32 roleId, address token)
         external
         returns (uint);

--- a/src/modules/base/Module_v1.sol
+++ b/src/modules/base/Module_v1.sol
@@ -296,7 +296,7 @@ abstract contract Module_v1 is
     /// @param role The role to check.
     /// @param addr The address to check.
     function _checkRoleModifier(bytes32 role, address addr) internal view {
-        if (!__Module_orchestrator.authorizer().hasRole(role, addr)) {
+        if (!__Module_orchestrator.authorizer().checkForRole(role, addr)) {
             revert Module__CallerNotAuthorized(role, addr);
         }
     }

--- a/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
+++ b/test/modules/authorizer/role/AUT_TokenGated_Roles_v1.t.sol
@@ -579,7 +579,9 @@ contract TokenGatedAUT_RoleV1Test is Test {
         assertEq(
             false, _authorizer.hasTokenRole(moduleRoleId, address(roleToken))
         );
-        assertEq(false, _authorizer.hasModuleRole(role, address(roleToken)));
+        assertEq(
+            false, _authorizer.checkForRole(moduleRoleId, address(roleToken))
+        );
 
         _authorizer.revokeRoleFromModule(role, address(roleToken));
 
@@ -631,7 +633,7 @@ contract TokenGatedAUT_RoleV1Test is Test {
 
             // we ensure both ways to check give the same result
             vm.prank(address(mockModule));
-            bool result = _authorizer.hasModuleRole(ROLE_TOKEN, callers[i]);
+            bool result = _authorizer.checkForRole(roleId, callers[i]);
             assertEq(result, _authorizer.hasTokenRole(roleId, callers[i]));
 
             // we verify the result ir correct
@@ -676,7 +678,7 @@ contract TokenGatedAUT_RoleV1Test is Test {
 
             // we ensure both ways to check give the same result
             vm.prank(address(mockModule));
-            bool result = _authorizer.hasModuleRole(ROLE_NFT, callers[i]);
+            bool result = _authorizer.checkForRole(roleId, callers[i]);
             assertEq(result, _authorizer.hasTokenRole(roleId, callers[i]));
 
             // we verify the result ir correct
@@ -713,11 +715,9 @@ contract TokenGatedAUT_RoleV1Test is Test {
 
         assertEq(true, _authorizer.hasRole(roleId, address(roleToken))); // The token has been added to the core authorizer mapping
 
+        assertEq(false, _authorizer.checkForRole(roleId, address(roleToken))); // The token itself  does not have the role
         assertEq(
-            false, _authorizer.hasModuleRole(ROLE_TOKEN, address(roleToken))
-        ); // The token itself  does not have the role
-        assertEq(
-            _authorizer.hasModuleRole(ROLE_TOKEN, address(roleToken)),
+            _authorizer.checkForRole(roleId, address(roleToken)),
             _authorizer.hasTokenRole(roleId, address(roleToken))
         ); // We ensure both ways to check give the same result
 
@@ -731,7 +731,7 @@ contract TokenGatedAUT_RoleV1Test is Test {
 
             // we ensure both ways to check give the same result
             vm.prank(address(mockModule));
-            bool result = _authorizer.hasModuleRole(ROLE_TOKEN, callers[i]);
+            bool result = _authorizer.checkForRole(roleId, callers[i]);
             assertEq(result, _authorizer.hasTokenRole(roleId, callers[i]));
 
             // we verify the result is correct
@@ -756,11 +756,9 @@ contract TokenGatedAUT_RoleV1Test is Test {
 
         assertEq(false, _authorizer.hasRole(roleId, address(roleToken))); // The token has been revoked from the core authorizer mapping
 
+        assertEq(false, _authorizer.checkForRole(roleId, address(roleToken))); // The token itsef still does not have the role
         assertEq(
-            false, _authorizer.hasModuleRole(ROLE_TOKEN, address(roleToken))
-        ); // The token itsef still does not have the role
-        assertEq(
-            _authorizer.hasModuleRole(ROLE_TOKEN, address(roleToken)),
+            _authorizer.checkForRole(roleId, address(roleToken)),
             _authorizer.hasTokenRole(roleId, address(roleToken))
         ); // We ensure both ways to check give the same result
 
@@ -774,7 +772,7 @@ contract TokenGatedAUT_RoleV1Test is Test {
 
             // we ensure both ways to check give the same result
             vm.prank(address(mockModule));
-            bool result = _authorizer.hasModuleRole(ROLE_TOKEN, callers[i]);
+            bool result = _authorizer.checkForRole(ROLE_TOKEN, callers[i]);
             assertEq(result, _authorizer.hasTokenRole(roleId, callers[i]));
 
             // we verify the user is not authorized

--- a/test/modules/logicModule/paymentClient/LM_PC_PaymentRouter_v1.t.sol
+++ b/test/modules/logicModule/paymentClient/LM_PC_PaymentRouter_v1.t.sol
@@ -97,12 +97,7 @@ contract LM_PC_PaymentRouter_v1_Test is ModuleTest {
         );
 
         vm.startPrank(address(paymentRouter));
-        assertEq(
-            _authorizer.hasModuleRole(
-                paymentRouter.PAYMENT_PUSHER_ROLE(), paymentPusher_user
-            ),
-            true
-        );
+        assertEq(_authorizer.checkForRole(roleId, paymentPusher_user), true);
         vm.stopPrank();
     }
 

--- a/test/utils/mocks/modules/AuthorizerV1Mock.sol
+++ b/test/utils/mocks/modules/AuthorizerV1Mock.sol
@@ -112,14 +112,12 @@ contract AuthorizerV1Mock is IAuthorizer_v1, Module_v1 {
         return _authorized[who] || _roleAuthorized[role][who] || _allAuthorized;
     }
 
-    function hasModuleRole(bytes32 role, address who)
+    function checkForRole(bytes32 role, address who)
         external
         view
         returns (bool)
     {
-        bytes32 roleId = generateRoleId(_msgSender(), role);
-        return
-            _authorized[who] || _roleAuthorized[roleId][who] || _allAuthorized;
+        return _authorized[who] || _roleAuthorized[role][who] || _allAuthorized;
     }
 
     function checkRoleMembership(bytes32 role, address who)


### PR DESCRIPTION
Applying the fixes after the Hats Review of the Macro Audit PR #540 (slightly adapted the one from @Zitzak as the `init` function of the `AUT_Roles_v1` contract is very different.

(Did a modification that was probably required, the discussion can be found below in my comment.)

Branch name was a mistake, should have been `apply-macro-audit-omega-fixes`