### PR TITLE
Chore: Rename Dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,9 @@
 [submodule "lib/openzeppelin-contracts-upgradeable"]
 	path = lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/openzeppelin/openzeppelin-contracts-upgradeable
-[submodule "lib/protocol"]
-	path = lib/protocol
-	url = https://github.com/UMAprotocol/protocol
 [submodule "lib/deterministic-factory"]
 	path = lib/deterministic-factory
 	url = https://github.com/InverterNetwork/deterministic-factory
+[submodule "lib/uma-protocol"]
+	path = lib/uma-protocol
+	url = https://github.com/UMAprotocol/protocol

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,7 +1,7 @@
 @oz-up/=lib/openzeppelin-contracts-upgradeable/contracts/
 @oz/=lib/openzeppelin-contracts/contracts/
 @df/=lib/deterministic-factory/src/
-@uma/=lib/protocol/packages/core/contracts/
+@uma/=lib/uma-protocol/packages/core/contracts/
 @ex/=src/external/
 @fm/=src/modules/fundingManager/
 @pp/=src/modules/paymentProcessor/


### PR DESCRIPTION
**Status**
⌛ Waiting for review...

--- 
**Description**
Found out that there is a way to define the name of `forge install` dependencies, so I've renamed the UMA protocol dependency from `protocol` to `uma-protocol`, to make it a bit clearer.

Made sure to use the same commit hash for the dependency itself, so nothing changed there.

Lmk if this is okay for you in general @0xNuggan 🙏 